### PR TITLE
tools: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,43 @@
+# Editor configuration options.
+# See: https://spec.editorconfig.org/
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[.editorconfig]
+max_line_length = off
+
+[Makefile]
+indent_style = tab
+
+[{*.py,*.pyi}]
+max_line_length = 88
+
+[{*.bash,*.sh,*.zsh}]
+indent_size = 2
+tab_width = 2
+
+[{*.har,*.json,*.json5}]
+indent_size = 2
+max_line_length = off
+
+[{*.markdown,*.md,*.rst}]
+max_line_length = off
+ij_visual_guides = none
+
+[{*.toml,Cargo.lock,Cargo.toml.orig,Gopkg.lock,Pipfile,poetry.lock}]
+max_line_length = off
+
+[{*.ini, *.cfg}]
+max_line_length = off
+
+[{*.yaml,*.yml}]
+indent_size = 2
+max_line_length = off


### PR DESCRIPTION
The editorconfig file will tell editors about our indentation, line end, character encoding, etc. This can all be overridden on a per-directory basis by adding another .editorconfig if necessary, but otherwise it'll just make editor settings easier.

Get the plugin for your editor (or don't - it won't break anything if you don't):
https://editorconfig.org/#download