### PR TITLE
tools: Make typing use an editable install

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,8 +56,6 @@ deps =
     ruff>=0.0.226
     # renovate: datasource=pypi
     codespell[tomli]>=2.2.2
-    # renovate: datasource=pypi
-    mypy[reports]>=0.991
 env_dir = {work_dir}/linting
 runner = ignore_env_name_mismatch
 
@@ -65,23 +63,38 @@ runner = ignore_env_name_mismatch
 find = find {tox_root} \( -name .git -o -name .tox \) -prune -o -print
 filter = file --mime-type -Nnf- | grep shellscript | cut -f1 -d:
 
-[testenv:lint-{black,ruff,pyright,shellcheck,codespell,mypy}]
+[testenv:lint-{black,ruff,shellcheck,codespell}]
 description = Lint the source code
 base = testenv, lint
 labels = lint
 allowlist_externals =
-    pyright: pyright
     shellcheck: bash, xargs
-    mypy: mkdir
 commands_pre =
-    mypy: mkdir -p .mypy_cache
     shellcheck: bash -c '{[shellcheck]find} | {[shellcheck]filter} > {env_tmp_dir}/shellcheck_files'
 commands =
     black: black --check --diff {tty:--color} {posargs} .
     ruff: ruff --diff --respect-gitignore {posargs} .
-    pyright: pyright --lib {posargs}
     shellcheck: xargs -ra {env_tmp_dir}/shellcheck_files shellcheck
     codespell: codespell --toml {tox_root}/pyproject.toml {posargs}
+
+[testenv:lint-{mypy,pyright}]
+description = Static type checking
+base = testenv
+deps =
+    # renovate: datasource=pypi
+    mypy[reports]>=0.991
+env_dir = {work_dir}/typing
+runner = ignore_env_name_mismatch
+package = editable
+extras = [dev, types]
+labels = lint, type
+allowlist_externals =
+    pyright: pyright
+    mypy: mkdir
+commands_pre =
+    mypy: mkdir -p .mypy_cache
+commands =
+    pyright: pyright --lib {posargs}
     mypy: mypy --install-types --non-interactive .
 
 [testenv:format-{black,ruff,codespell}]


### PR DESCRIPTION
Most static checks don't need the code to be installed at all, but type checking can require the code and its dependencies.