### PR TITLE
lint: specify a single ruff version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ deps =
     # renovate: datasource=pypi
     black>=22.12.0
     # renovate: datasource=pypi
-    ruff==0.0.226
+    ruff==0.0.236
     # renovate: datasource=pypi
     codespell[tomli]>=2.2.2
 env_dir = {work_dir}/linting


### PR DESCRIPTION
Ensure that ruff only gets updated by renovate or explicitly in PRs. This will prevent random CI breakages until ruff is stable.