### PR TITLE
lint(shellcheck): replace `find` with `git ls-files`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ env_dir = {work_dir}/linting
 runner = ignore_env_name_mismatch
 
 [shellcheck]
-find = find {tox_root} \( -name .git -o -name .tox \) -prune -o -print
+find = git ls-files
 filter = file --mime-type -Nnf- | grep shellscript | cut -f1 -d:
 
 [testenv:lint-{black,ruff,shellcheck,codespell,yaml}]


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

Inspired by https://github.com/snapcore/snapcraft/pull/4040 and https://github.com/canonical/rockcraft/pull/196.