### PR TITLE
ci: don't upload test results when cancelling the workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,7 +72,7 @@ jobs:
           directory: ./results/
           files: coverage*.xml
       - name: Upload test results
-        if: always()
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: test-results-${{ matrix.platform }}


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

- [x ] Have you followed the guidelines for contributing?
- [x ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x ] Have you successfully run `tox`?

-----
