### PR TITLE
docs: update sphinx to 6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ types = [
 ]
 docs = [
     "furo==2023.3.27",
-    "sphinx==5.3.0",
+    "sphinx>=6.2.1,<7.0",
     "sphinx-autobuild==2021.3.14",
     "sphinx-copybutton==0.5.2",
     "sphinx-design==0.4.1",


### PR DESCRIPTION
Furo currently blocks us from updating to sphinx 7 https://github.com/pradyunsg/furo/pull/653

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
