### PR TITLE
ci: add inclusive naming linter

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,6 +38,10 @@ jobs:
           echo "::endgroup::"
       - name: Run Linters
         run: tox run -m lint
+      - name: Lint inclusive naming
+        uses: canonical-web-and-design/inclusive-naming@main
+        with:
+          fail-on-error: true
   tests:
     strategy:
       matrix:


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `tox`?

-----

Testing the workflow.  

I'm wondering if running `woke` as a linter inside `tox` would be better.  We could call `woke` directly (something like [this](https://github.com/canonical/Inclusive-naming/blob/f489db626ecc7c5ab79deafa4556a674a2728862/entrypoint.sh#L22)).

This action appears to be heavily integrated with reviewdog (a GH auto-commenting bot), so the [failing output](https://github.com/canonical/starbase/actions/runs/5027902650/jobs/9017974056?pr=74) isn't very useful.