### PR TITLE
meta: use snapcraft's versioning scheme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,19 @@ readme = {file = "README.rst"}
 
 [tool.setuptools_scm]
 write_to = "starcraft/_version.py"
+# the version comes from the latest annotated git tag formatted as 'X.Y.Z'
+# standard version scheme:
+#   'X.Y.Z.post<commits since tag>+g<hash>'
+# scheme when no tags exist:
+#   '0.0.post<total commits>+g<hash>
+# scheme when no tags exist and working dir is dirty:
+#   '0.0.post<total commits>+g<hash>.d<date formatted as %Y%m%d>'
+version_scheme = "post-release"
+# deviations from the default 'git describe' command:
+# - only match annotated tags
+# - only match tags formatted as 'X.Y.Z'
+# - exclude '+dirty<hash>' suffix
+git_describe_command = "git describe --long --match '[0-9]*.[0-9]*.[0-9]*' --exclude '*[^0-9.]*'"
 
 [tool.setuptools.packages.find]
 exclude = [

--- a/tests/integration/starbase/test_version.py
+++ b/tests/integration/starbase/test_version.py
@@ -1,0 +1,65 @@
+# This file is part of starcraft.
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Starcraft versioning tests."""
+import re
+import subprocess
+
+import pytest
+import starcraft
+
+
+def _repo_has_version_tag() -> bool:
+    """Returns True if the repo has a git tag usable for versioning."""
+    git_describe_command = [
+        "git",
+        "describe",
+        "--always",
+        "--long",
+        "--match",
+        "[0-9]*.[0-9]*.[0-9]*",
+        "--exclude",
+        "*[^0-9.]*",
+    ]
+    output = subprocess.run(
+        git_describe_command, check=True, capture_output=True, text=True
+    ).stdout.rstrip("\n")
+
+    # match on 'X.Y.Z-<commits since tag>-g<hash>'
+    return bool(re.fullmatch(r"\d+\.\d+\.\d+-\d+-g[0-9a-f]+", output))
+
+
+@pytest.mark.skipif(
+    _repo_has_version_tag(), reason="Skipping because project was versioned from a tag."
+)
+def test_version_without_tags():
+    """Validate version format when no valid tag are present."""
+    version = starcraft.__version__
+
+    # match on '0.0.post<total commits>+g<hash>'
+    #       or '0.0.post<total commits>+g<hash>.d<date formatted as %Y%m%d>'
+    assert re.fullmatch(r"\d+\.\d+\.post\d+\+g[0-9a-f]+(\.d[0-9]*)?", version)
+
+
+@pytest.mark.skipif(
+    not _repo_has_version_tag(),
+    reason="Skipping because project was not versioned from a tag.",
+)
+def test_version_with_tags():
+    """Version should be properly formatted when a valid tag exists."""
+    version = starcraft.__version__
+
+    # match on 'X.Y.Z.post<commits since tag>+g<hash>'
+    assert re.fullmatch(r"\d+\.\d+\.\d+\.post\d+\+g[0-9a-f]+", version)


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `tox`?

-----

The versioning is now a close match to [snapcraft's versioning scheme](https://github.com/snapcore/snapcraft/blob/6b94548db638ddb17acf49b7340a2b801a1ab4e7/tools/version.py#L25-L30) using [setuptools-scm](https://github.com/pypa/setuptools_scm/tree/main).  Getting it any closer will require creating a custom [Version](https://github.com/pypa/packaging/blob/63f4cfe679fb3d9322e56d8569207ecff4735238/src/packaging/version.py#L157) class.

(CRAFT-1794)