### PR TITLE
lint: fix mypy config to 'recurse'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ disallow_untyped_decorators = true
 disallow_any_generics = true
 
 [[tool.mypy.overrides]]
-module = ["starcraft"]
+module = ["starcraft.*"]
 disallow_untyped_defs = true
 no_implicit_optional = true
 


### PR DESCRIPTION
`module = ["starcraft"]` only checks checks the `starcraft` main package, and not any sub-packages and modules.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
