### PR TITLE
meta: add dirty flag to versioning scheme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,18 +56,19 @@ readme = {file = "README.rst"}
 [tool.setuptools_scm]
 write_to = "starcraft/_version.py"
 # the version comes from the latest annotated git tag formatted as 'X.Y.Z'
-# standard version scheme:
-#   'X.Y.Z.post<commits since tag>+g<hash>'
-# scheme when no tags exist:
-#   '0.0.post<total commits>+g<hash>
-# scheme when no tags exist and working dir is dirty:
-#   '0.0.post<total commits>+g<hash>.d<date formatted as %Y%m%d>'
+# version scheme:
+#   - X.Y.Z.post<commits since tag>+g<hash>.d<%Y%m%d>
+# parts of scheme:
+#   - X.Y.Z - most recent git tag
+#   - post<commits since tag>+g<hash> - present when current commit is not tagged
+#   - .d<%Y%m%d> - present when working dir is dirty
+# version scheme when no tags exist:
+#   - 0.0.post<total commits>+g<hash>
 version_scheme = "post-release"
 # deviations from the default 'git describe' command:
 # - only match annotated tags
 # - only match tags formatted as 'X.Y.Z'
-# - exclude '+dirty<hash>' suffix
-git_describe_command = "git describe --long --match '[0-9]*.[0-9]*.[0-9]*' --exclude '*[^0-9.]*'"
+git_describe_command = "git describe --dirty --long --match '[0-9]*.[0-9]*.[0-9]*' --exclude '*[^0-9.]*'"
 
 [tool.setuptools.packages.find]
 exclude = [

--- a/tests/integration/test_version.py
+++ b/tests/integration/test_version.py
@@ -49,7 +49,7 @@ def test_version_without_tags():
     version = starcraft.__version__
 
     # match on '0.0.post<total commits>+g<hash>'
-    #       or '0.0.post<total commits>+g<hash>.d<date formatted as %Y%m%d>'
+    #       or '0.0.post<total commits>+g<hash>.d<%Y%m%d>'
     assert re.fullmatch(r"\d+\.\d+\.post\d+\+g[0-9a-f]+(\.d[0-9]*)?", version)
 
 
@@ -61,5 +61,8 @@ def test_version_with_tags():
     """Version should be properly formatted when a valid tag exists."""
     version = starcraft.__version__
 
-    # match on 'X.Y.Z.post<commits since tag>+g<hash>'
-    assert re.fullmatch(r"\d+\.\d+\.\d+\.post\d+\+g[0-9a-f]+", version)
+    # match on 'X.Y.Z'
+    #       or 'X.Y.Z.d<%Y%m%d>'
+    #       or 'X.Y.Z.post<commits since tag>+g<hash>'
+    #       or 'X.Y.Z.post<commits since tag>+g<hash>.d<%Y%m%d>'
+    assert re.fullmatch(r"\d+\.\d+\.\d+(\.post\d+\+g[0-9a-f]+)?(\.d[0-9]*)?", version)


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `tox`?

-----

Adds a dirty flag to the version when the working dir is dirty.

This functionality was already part of `setuptool_scm`.  I had previously removed it to keep aligned with [snapcraft's scheme](https://github.com/snapcore/snapcraft/blob/40136ea9b59351e4f9f1fbed8c4d8c0db873c488/tools/version.py#L24).  After an offline discussion, I think it's better to align with `setuptools_scm`.

Also moves the integration test up a directory.