### PR TITLE
tests: provide a fixture with the project's 'main' module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+import types
+
+import pytest
+
+
+@pytest.fixture()
+def project_main_module() -> types.ModuleType:
+    """Fixture that returns the project's principal package (imported).
+
+    This fixture should be rewritten by "downstream" projects to return the correct
+    module. Then, every test that uses this fixture will correctly test against the
+    downstream project.
+    """
+    try:
+        # This should be the project's main package; downstream projects must update this.
+        import starcraft
+
+        main_module = starcraft
+    except ImportError:
+        pytest.fail(
+            "Failed to import the project's main module: check if it needs updating"
+        )
+    return main_module

--- a/tests/integration/test_setuptools.py
+++ b/tests/integration/test_setuptools.py
@@ -1,5 +1,3 @@
-# This file is part of starcraft.
-#
 # Copyright 2023 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
@@ -13,14 +11,14 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Starcraft integration tests related to building the package."""
+"""Integration tests related to building the package."""
 import re
 import subprocess
 from pathlib import Path
 from zipfile import ZipFile
 
 
-def test_packages(tmp_path, request):
+def test_packages(project_main_module, tmp_path, request):
     """Check wheel generation from our pyproject.toml"""
     root_dir = Path(request.config.rootdir)
     out_dir = tmp_path
@@ -29,10 +27,12 @@ def test_packages(tmp_path, request):
     assert len(wheels) == 1
     wheel = wheels[0]
 
-    starcraft_files = []
+    main_module = project_main_module.__name__
+
+    project_files = []
 
     dist_files = []
-    dist_info_re = re.compile("starcraft-.*.dist-info")
+    dist_info_re = re.compile(f"{main_module}-.*.dist-info")
 
     invalid = []
 
@@ -41,15 +41,15 @@ def test_packages(tmp_path, request):
         assert len(names) > 1
         for name in names:
             top = name.parts[0]
-            if top == "starcraft":
-                starcraft_files.append(name)
+            if top == main_module:
+                project_files.append(name)
             elif dist_info_re.match(top):
                 dist_files.append(top)
             else:
                 invalid = []
 
-    # Only the top-level "starcraft" dir should be present, plus the
-    # starcraft-xyz-dist-info/ entries.
-    assert starcraft_files, "No 'starcraft' modules were packaged!"
+    # Only the top-level "project_name" dir should be present, plus the
+    # project_name-xyz-dist-info/ entries.
+    assert project_files, f"No '{main_module}' modules were packaged!"
     assert dist_files, "The dist-info directory was not created!"
     assert not invalid, f"Invalid files were packaged: {invalid}"

--- a/tests/integration/test_version.py
+++ b/tests/integration/test_version.py
@@ -1,5 +1,3 @@
-# This file is part of starcraft.
-#
 # Copyright 2023 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
@@ -13,12 +11,11 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Starcraft versioning tests."""
+"""Versioning tests."""
 import re
 import subprocess
 
 import pytest
-import starcraft
 
 
 def _repo_has_version_tag() -> bool:
@@ -44,9 +41,9 @@ def _repo_has_version_tag() -> bool:
 @pytest.mark.skipif(
     _repo_has_version_tag(), reason="Skipping because project was versioned from a tag."
 )
-def test_version_without_tags():
+def test_version_without_tags(project_main_module):
     """Validate version format when no valid tag are present."""
-    version = starcraft.__version__
+    version = project_main_module.__version__
 
     # match on '0.0.post<total commits>+g<hash>'
     #       or '0.0.post<total commits>+g<hash>.d<%Y%m%d>'
@@ -57,9 +54,9 @@ def test_version_without_tags():
     not _repo_has_version_tag(),
     reason="Skipping because project was not versioned from a tag.",
 )
-def test_version_with_tags():
+def test_version_with_tags(project_main_module):
     """Version should be properly formatted when a valid tag exists."""
-    version = starcraft.__version__
+    version = project_main_module.__version__
 
     # match on 'X.Y.Z'
     #       or 'X.Y.Z.d<%Y%m%d>'


### PR DESCRIPTION
The idea is this: since we have a few tests that are worth running in "downstream" projects (those that merge starbase periodically), instead of having to adapt every test individually in every downstream project we'll use a fixture (project_main_module) that provides the imported module object. So in starbase is returns the 'starcraft' module.

The tests are then updated to use this fixture instead of importing the module directly. Downstream projects therefore only need to update the fixture's implementation and the tests will (well, should) work.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

Feel free to shoot this PR down, we can reject this with no problems. It's just an idea that occurred to me because the versioning and packaging tests are actually very useful in downstream projects too.
