### PR TITLE
coverage: automatically exclude type checking blocks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,9 @@ omit = ["tests/**"]
 [tool.coverage.report]
 skip_empty = true
 fail_under = 80
+exclude_also = [
+    "if (typing\\.)?TYPE_CHECKING:",
+]
 
 [tool.pyright]
 strict = ["starcraft"]


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

This will automatically exclude type-checking guard blocks from coverage, as they are never run.