### PR TITLE
ruff: remove type-checking guard blocks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,8 @@ select = [  # Base linting rule selections.
     "RSE",  # Errors on pytest raises.
     "RET",  # Simpler logic after return, raise, continue or break
     "SIM",  # Code simplification
-    "TCH",  # Guard imports only used for type checking behind a type-checkning block.
+    "TCH004",  # Remove imports from type-checking guard blocks if used at runtime
+    "TCH005",  # Delete empty type-checking blocks
     "ARG",  # Unused arguments
     "PTH",  # Migrate to pathlib
     "ERA",  # Don't check in commented out code


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

After internal discussion it was decided that mandating type-checking guard blocks is not preferred.