### PR TITLE
ci(renovate): allow more branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -94,6 +94,7 @@
   automergeSchedule: ["every weekend"],
   schedule: ["every weekend"],
   prConcurrentLimit: 2, // No more than 2 open PRs at a time.
+  branchConcurrentLimit: 20, // No more than 20 open branches at a time.
   prCreation: "not-pending", // Wait until status checks have completed before raising the PR
   prNotPendingHours: 4, // ...unless the status checks have been running for 4+ hours.
   prHourlyLimit: 1, // No more than 1 PR per hour.


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

`branchConcurrentLimit` was implicitly set to `prConcurrentLimit`, which can prevent automerges and PR from being created.

source: https://github.com/canonical/craft-providers/pull/395

https://docs.renovatebot.com/configuration-options/#branchconcurrentlimit