### PR TITLE
style: ensure ruff picks up pydantic.validator for class methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,10 @@ ignore = [
     "TRY003",  # Avoid specifying long messages outside the exception class
 ]
 
+[tool.ruff.pep8-naming]
+# Allow Pydantic's `@validator` decorator to trigger class method treatment.
+classmethod-decorators = ["pydantic.validator"]
+
 [tool.ruff.per-file-ignores]
 "tests/**.py" = [  # Some things we want for the moin project are unnecessary in tests.
     "D",  # Ignore docstring rules in tests


### PR DESCRIPTION
see: https://docs.astral.sh/ruff/settings/#pep8-naming-classmethod-decorators

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
