### PR TITLE
ci: colorize tox

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,9 +27,9 @@ jobs:
       - name: Install Tox
         run: pip install tox
       - name: Lint documentation
-        run: tox run -e lint-docs
+        run: tox run --colored yes -e lint-docs
       - name: Build documentation
-        run: tox run -e build-docs
+        run: tox run --colored yes -e build-docs
       - name: Upload documentation
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,13 +35,13 @@ jobs:
           python -m pip install tox
           echo "::endgroup::"
           echo "::group::Create virtual environments for linting processes."
-          tox run -m lint --notest
+          tox run --colored yes -m lint --notest
           echo "::endgroup::"
           echo "::group::Wait for snap to complete"
           snap watch --last=install
           echo "::endgroup::"
       - name: Run Linters
-        run: tox run --skip-pkg-install --no-list-dependencies -m lint
+        run: tox run --skip-pkg-install --no-list-dependencies --colored yes -m lint
   unit:
     strategy:
       matrix:
@@ -67,9 +67,9 @@ jobs:
           echo "::endgroup::"
           mkdir -p results
       - name: Setup Tox environments
-        run: tox run -m tests --notest
+        run: tox run --colored yes -m tests --notest
       - name: Test with tox
-        run: tox run --skip-pkg-install --no-list-dependencies --result-json results/tox-${{ matrix.platform }}.json -m unit-tests
+        run: tox run --skip-pkg-install --no-list-dependencies --result-json results/tox-${{ matrix.platform }}.json --colored yes -m unit-tests
         env:
           PYTEST_ADDOPTS: "--no-header -vv -rN"
       - name: Upload code coverage
@@ -108,9 +108,9 @@ jobs:
           echo "::endgroup::"
           mkdir -p results
       - name: Setup Tox environments
-        run: tox run -m tests --notest
+        run: tox run --colored yes -m tests --notest
       - name: Test with tox
-        run: tox run --skip-pkg-install --no-list-dependencies --result-json results/tox-${{ matrix.platform }}.json -m integration-tests
+        run: tox run --skip-pkg-install --no-list-dependencies --result-json results/tox-${{ matrix.platform }}.json --colored yes -m integration-tests
         env:
           PYTEST_ADDOPTS: "--no-header -vv -rN"
       - name: Upload test results


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Colorize the output of tox in Github CI.

Tox does not colorize its output in Github because of the envvar `TERM` is set to `dumb`. However, github handles colorized output quite nicely.

Upstream of https://github.com/snapcore/snapcraft/pull/4435 / https://github.com/canonical/craft-providers/pull/442