### PR TITLE
chore(deps): include ruff in dev updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,7 +39,6 @@
         "lint",
         "types"
       ],
-      excludePackagePatterns: ["ruff"],
       matchUpdateTypes: ["minor", "patch", "pin", "digest"],
       prPriority: -1,
       automerge: true
@@ -63,12 +62,6 @@
       groupSlug: "dev-dependencies",
       matchDepTypes: ["devDependencies"],
       matchUpdateTypes: ["major"],
-      prPriority: -3
-    },
-    {
-      // Ruff is still unstable, so update it separately.
-      groupName: "ruff",
-      matchPackagePatterns: ["^(lint/)?ruff$"],
       prPriority: -3
     }
   ],


### PR DESCRIPTION
Now that ruff has had a 0.1 release it should be updatable with our other linters.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
