### PR TITLE
ci(renovate): enable hotfix branch patch updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,19 +2,21 @@
   // Configuration file for RenovateBot: https://docs.renovatebot.com/configuration-options
   extends: ["config:base"],
   labels: ["dependencies"],  // For convenient searching in GitHub
+  baseBranches: ["$default", "/^hotfix\\/.*/"],
   pip_requirements: {
     fileMatch: ["^tox.ini$", "(^|/)requirements([\\w-]*)\\.txt$", "^.pre-commit-config.yaml$"]
   },
    packageRules: [
     {
       // Internal package minor patch updates get top priority, with auto-merging
-      groupName: "internal package patch releases",
+      groupName: "internal package minor releases",
       matchPackagePatterns: ["^craft-.*"],
       matchUpdateTypes: ["minor", "patch", "pin", "digest"],
       prPriority: 10,
       automerge: true,
       minimumReleaseAge: "0 seconds",
       schedule: ["at any time"],
+      matchBaseBranches: ["$default"],  // Only do minor releases on main
     },
     {
       // Same as above, but for hotfix branches, only for patch, and without auto-merging.
@@ -40,7 +42,8 @@
       groupName: "internal packages",
       matchDepPatterns: ["craft-.*", "snap-.*"],
       matchLanguages: ["python"],
-      prPriority: 2
+      prPriority: 2,
+      matchBaseBranches: ["$default"],  // Not for hotfix branches
     },
     {
       // GitHub Actions are higher priority to update than most dependencies since they don't tend to break things.
@@ -75,11 +78,13 @@
       matchPackageNames: ["Sphinx", "furo"],
       matchPackagePatterns: ["[Ss]phinx.*$"],
       matchDepPatterns: ["docs/.*"],
+      matchBaseBranches: ["$default"],  // Not for hotfix branches
     },
     {
       // Other major dependencies get deprioritised below minor dev dependencies.
       matchUpdateTypes: ["major"],
-      prPriority: -2
+      prPriority: -2,
+      matchBaseBranches: ["$default"],  // Not for hotfix branches
     },
     {
       // Major dev dependencies are stone last, but grouped.
@@ -87,13 +92,15 @@
       groupSlug: "dev-dependencies",
       matchDepTypes: ["devDependencies"],
       matchUpdateTypes: ["major"],
-      prPriority: -3
+      prPriority: -3,
+      matchBaseBranches: ["$default"],  // Not for hotfix branches
     },
     {
       // Pyright makes regular breaking changes in patch releases, so we separate these
       // and do them independently.
       matchPackageNames: ["pyright", "types/pyright"],
-      prPriority: -4
+      prPriority: -4,
+      matchBaseBranches: ["$default"],  // Not for hotfix branches
     }
   ],
   regexManagers: [

--- a/.github/workflows/check-renovate.yaml
+++ b/.github/workflows/check-renovate.yaml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - name: Install renovate
         run: npm install --global renovate
       - name: Enable ssh access


### PR DESCRIPTION
This lets Renovate update patch dependencies on hotfix branches.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
