### PR TITLE
chore(renovate): fewer PRs to hotfix branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,7 +32,11 @@
       // Automerge patches, pin changes and digest changes.
       // Also groups these changes together.
       groupName: "bugfixes",
-      excludeDepPatterns: ["lint/.*", "types/.*"],
+      excludeDepPatterns: [
+        "lint/.*",
+        "types/.*",
+        "pyright",  // Pyright needs to be done separately.
+      ],
       matchUpdateTypes: ["patch", "pin", "digest"],
       prPriority: 3, // Patches should go first!
       automerge: true
@@ -57,6 +61,7 @@
       //Do all pydantic-related updates together
       groupName: "pydantic etc.",
       matchPackagePatterns: ["^pydantic"],
+      matchBaseBranches: ["$default"],  // Only do minor releases on main
     },
     {
       // Minor changes can be grouped and automerged for dev dependencies, but are also deprioritised.
@@ -91,7 +96,8 @@
       ],
       matchUpdateTypes: ["minor", "patch", "pin", "digest"],
       prPriority: -1,
-      automerge: true
+      automerge: true,
+      matchBaseBranches: ["$default"],  // Not for hotfix branches
     },
     {
       // Documentation related updates


### PR DESCRIPTION
Renovate should only PR to hotfix branches for non-dev patch updates.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

Lint issue is unrelated.
