### PR TITLE
docs: update readme and template, fix build error

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,12 +10,12 @@ sphinx:
   configuration: docs/conf.py
 
 # Optionally build your docs in additional formats such as PDF
-formats:
-  - pdf
-  - epub
+#formats:
+#  - pdf
+#  - epub
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3"
 

--- a/README.rst
+++ b/README.rst
@@ -2,37 +2,42 @@
 starbase
 ********
 
-A base repository for Starcraft projects.
+The base repository for Starcraft projects.
 
 Description
 -----------
-This project is designed to act as the basis for any future starcraft projects
-as well as a testbed for any tooling changes we want to make before merging
-them into other projects.
+This template code is the basis for all future starcraft projects, and acts as
+the testbed for any major tooling changes that we want to make before
+propagating them across all projects.
 
 Structure
 ---------
 TODO
 
-How to migrate existing projects
+Migrate existing projects
 --------------------------------
 TODO
 
-How to create a new project
+Create a new project
 ---------------------------
 [TODO: Make this a template repository.]
 
 #. `Use this template`_ to create your repository.
 #. Ensure the ``LICENSE`` file represents the current best practices from the
-   Canonical legal team for the specific project you intend to release. (LGPL v3
-   for libraries, GPL v3 for applications.)
+   Canonical legal team for the specific project you intend to release. We use
+   LGPL v3 for libraries, and GPL v3 for apps.
 #. Rename any files or directories and ensure references are updated.
-#. Replace any appropriate ``starcraft`` references with the appropriate name.
-#. Put correct contact information into CODE_OF_CONDUCT.md
-#. Write a new README
-#. Import your documentation to ReadTheDocs_.
+#. Replace any instances of the word ``Starcraft`` with the product's name.
+#. Place contact information in a code of conduct.
+#. Rewrite the README.
+#. If a Diataxis quadrant (tutorials, how-tos, references, explanations)
+   doesn't yet have content, remove its landing page from the TOC and delete
+   its card in ``docs/index.rst``. You can re-index it when at least one
+   document has been produced for it.
+#. Register the product's documentation on our custom domain on `Read the
+   Docs for Business`_.
 
 .. _EditorConfig: https://editorconfig.org/
 .. _pre-commit: https://pre-commit.com/
-.. _ReadTheDocs: https://docs.readthedocs.io/en/stable/intro/import-guide.html
+.. _Read the Docs for Business: https://library.canonical.com/documentation/publish-on-read-the-docs
 .. _use this template: https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
 .. starcraft documentation root file
 
-StarCraft
+Starcraft
 =========
 
 .. toctree::


### PR DESCRIPTION
- Clarify the wording in the README, add more details about preparing the docs.
- Disable PDF and EPUB generation. We can re-enable this later when we rebase the docs and those builds are working again.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?
-----
