### PR TITLE
ci(rtd): pin python version to 3.12

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,7 @@ sphinx:
 build:
   os: ubuntu-24.04
   tools:
-    python: "3"
+    python: "3.12"
 
 python:
   install:


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

RTD updated their CI on Tuesday 19th November 2024, switching default version of python `3` from `3.12` to `3.13`.
As `starbase` does not support this version yet, we'll pin the version to the latest supported one.

Closes: #283 
(CRAFT-3710)
