### PR TITLE
docs: add release notes index and template

### DIFF
--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -1,7 +1,7 @@
 .. _explanation:
 
 Explanation
-***********
+===========
 
 .. toctree::
    :maxdepth: 1

--- a/docs/how-to-guides/index.rst
+++ b/docs/how-to-guides/index.rst
@@ -1,7 +1,7 @@
-.. _howto:
+.. _how-to-guides:
 
 How-to guides
-*************
+=============
 
 .. toctree::
    :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,16 +8,17 @@ Starcraft
    :hidden:
 
    tutorials/index
-   howto/index
+   how-to-guides/index
    reference/index
    explanation/index
+   release-notes/index
 
 
 .. list-table::
 
-    * - | :ref:`Tutorial <tutorial>`
+    * - | :ref:`Tutorial <tutorials>`
         | **Get started** with a hands-on introduction to Starcraft
-    * - | :ref:`How-to guides <howto>`
+    * - | :ref:`How-to guides <how-to-guides>`
         | **Step-by-step guides** covering key operations and common tasks
     * - | :ref:`Reference <reference>`
         | **Technical information** about Starcraft
@@ -26,7 +27,7 @@ Starcraft
 
 
 Project and community
-=====================
+---------------------
 
 Starcraft is a member of the Canonical family. It's an open source project
 that warmly welcomes community projects, contributions, suggestions, fixes
@@ -36,8 +37,9 @@ and constructive feedback.
 * `Canonical contributor licenses agreement
   <https://ubuntu.com/legal/contributors>`_.
 
+
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,13 +1,13 @@
 .. _reference:
 
 Reference
-*********
+=========
 
 .. toctree::
    :maxdepth: 1
 
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -68,7 +68,7 @@ numbers for major, minor, and patch versions.
     * - Major
       - **3**.1.2
       - <Apps: "A change that drops support for an earlier software base.">
-        
+
         <Libraries: "A change that breaks compatibility with the previous
         version.">
     * - Minor
@@ -83,7 +83,7 @@ Long-term support
 -----------------
 
 Starcraft doesn't have long-term support (LTS) releases. However, we typically
-deliver a compatibility patch shortly after Ubuntu LTS releases to ensure
+deliver a compatibility release shortly after Ubuntu LTS releases to ensure
 continuity.
 
 Starcraft software bases are derived from Ubuntu LTS releases, and their
@@ -114,15 +114,14 @@ development keeps pace with the OS's new releases and support lifecycle.
   previous paragraph and add a separate list here, with the same format of
   "<package> or higher".>
 
-  For development and testing, Starcraft requires a <architecture>
-  system or VM with a minimum of <number>GB RAM.
+  For development and testing, Starcraft requires a <architecture> system or VM
+  with a minimum of <number>GB RAM.
 
 
   What's new
   ----------
 
-  Starcraft 1.0 brings the following features, integrations, and
-  improvements.
+  Starcraft 1.0 brings the following features, integrations, and improvements.
 
 
   <Important change>
@@ -148,14 +147,15 @@ development keeps pace with the OS's new releases and support lifecycle.
   <Paragraph 1, optional: Briefly cover the previous behaviour or the change in
   circumstances. For example, "With Ubuntu 24.04 LTS, the Snap Store and App
   Center now collect public reviews for snaps and assign an averaged score to
-  them to provide users and authors an avenue for discoverability and feedback.">
+  them to provide users and authors an avenue for discoverability and
+  feedback.">
 
   <Paragraph 2: Present the new behaviour or feature. In words, *show* what the
-  feature is and make a case for how the reader could benefit from it. Centre the
-  user whenever possible ("you"), and speak on behalf of Canonical ("we"). Prefer
-  general, simple usage over complex applications. Use past tense. For example,
-  "We understand that some authors may not want to have their snaps publicly
-  ranked. If you prefer to disable ranking for your snap, we added the
+  feature is and make a case for how the reader could benefit from it. Centre
+  the user whenever possible ("you"), and speak on behalf of Canonical ("we").
+  Prefer general, simple usage over complex applications. Use past tense. For
+  example, "We understand that some authors may not want to have their snaps
+  publicly ranked. If you prefer to disable ranking for your snap, we added the
   ``feedback`` key in Snapcraft recipes, which contains child keys for
   controlling many of the rating and feedback features in the store. You can
   declare ``voting: false`` to disable voting".>
@@ -163,8 +163,9 @@ development keeps pace with the OS's new releases and support lifecycle.
   <Paragraph 3, optional: Provide a call to action. This could take several
   forms, such as a call to immediately perform a relevant action in Starcraft,
   solicititation of the reader's feedback on a form or forum, or a link to
-  documentation, demo, blog post, and so on. For example, "See ``:ref:`Manage store
-  profile``` to configure how the public can engage with your snap on the store".>
+  documentation, demo, blog post, and so on. For example, "See ``:ref:`Manage
+  store profile``` to configure how the public can engage with your snap on the
+  store".>
 
 
   Minor features
@@ -197,44 +198,47 @@ development keeps pace with the OS's new releases and support lifecycle.
   adequate for protecting data in transit".>
 
   <Paragraph 2: State precisely what was removed or disabled. Advise on an
-  alternative solution, or state if no alternative exists. If necessary, describe
-  the consequences of the reader's inaction. Link to relevant documentation,
-  standards, or public discussion. For example, "In accordance with the report,
-  Starcraft 1.0 no longer supports encryption algorithm X. As of this release, if
-  you haven't already we highly recommend you immediately switch to encryption
-  algorithm Y to ensure your data stays protected. For more details about this
-  decision and our policy, see ```Security notice on encryption X <>`_`` on the
-  Ubuntu blog.">
+  alternative solution, or state if no alternative exists. If necessary,
+  describe the consequences of the reader's inaction. Link to relevant
+  documentation, standards, or public discussion. For example, "In accordance
+  with the report, Starcraft 1.0 no longer supports encryption algorithm X. As
+  of this release, if you haven't already we highly recommend you immediately
+  switch to encryption algorithm Y to ensure your data stays protected. For
+  more details about this decision and our policy, see ```Security notice on
+  encryption X <>`_`` on the Ubuntu blog.">
 
 
   Deprecated features in Starcraft 1.0
   ------------------------------------
 
-  The following features should no longer be used in Starcraft 1.0, and will be removed in Starcraft 1.1.
+  The following features should no longer be used in Starcraft 1.0, and will be
+  removed in Starcraft 1.1.
 
 
   Deprecated <feature z>
   ~~~~~~~~~~~~~~~~~~~~~~
 
-  <Use the same format as backwards-incompatible changes, but use future tense to
-  describe what we *intend* and *plan* to do in subsequent releases. Think of
-  this as a promise or commitment to the reader, and be mindful of the trust we
-  want them to place in us. Don't write conjecture or make promises about details
-  that haven't been decided. Include only the decisions that we have set in stone
-  and information we're allowed to disclose at of the release day. Use phrases
-  like "we plan to", or "we are working on", or "we have scheduled development
-  of". End by linking to relevant documentation, standards, or public discussion.
-  For example, "In October 2024, the NIST published SP ABC-123, urging software
-  publishers to cease the use of encryption algorithm X. We are deprecating its
-  usage in this release, and plan to remove it in Starcraft 1.1. For more details
-  about this decision and our policy, see ```Security notice on encryption X <>`_``
-  on the Ubuntu blog.">
+  <Use the same format as backwards-incompatible changes, but use future tense
+  to describe what we *intend* and *plan* to do in subsequent releases. Think
+  of this as a promise or commitment to the reader, and be mindful of the trust
+  we want them to place in us. Don't write conjecture or make promises about
+  details that haven't been decided. Include only the decisions that we have
+  set in stone and information we're allowed to disclose at of the release day.
+  Use phrases like "we plan to", or "we are working on", or "we have scheduled
+  development of". End by linking to relevant documentation, standards, or
+  public discussion. For example, "In October 2024, the NIST published SP
+  ABC-123, urging software publishers to cease the use of encryption algorithm
+  X. We are deprecating its usage in this release, and plan to remove it in
+  Starcraft 1.1. For more details about this decision and our policy, see
+  ```Security notice on encryption X <>`_`` on the Ubuntu blog.">
 
 
   Known issues
   ------------
 
-  The following issues are known and scheduled to be fixed in upcoming patch releases.
+  The following issues are known and scheduled to be fixed in upcoming patch
+  releases.
+
   See individual issue links for any mitigations.
 
   - <Ticket ID> <Title>

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -108,8 +108,8 @@ continuity.
   previous paragraph and add a separate list here, with the same format of
   "<package> or higher".>
 
-  For development and testing, Starcraft requires at minimum a <architecture>
-  system or VM with <number>GB RAM.
+  For development and testing, Starcraft requires a <architecture>
+  system or VM with a minimum of <number>GB RAM.
 
 
   What's new

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -53,7 +53,10 @@ Canonical is committed to supporting the <"latest major release" or "last two
 major releases"> of Starcraft. <Optional: "We forward-port changes in older
 releases to the latest release, if they're compatible.">
 
-Starcraft is released according to the Semantic Versioning 2.0.0 scheme with
+Starcraft is released when it achieves development milestones in its product
+lifecycle. It doesn't follow a predefined release cadence.
+
+Starcraft release naming follows the Semantic Versioning 2.0.0 scheme with
 numbers for major, minor, and patch versions.
 
 .. list-table::
@@ -64,16 +67,16 @@ numbers for major, minor, and patch versions.
       - Significance
     * - Major
       - **3**.1.2
-      - A change that breaks compatibility with the previous version.
+      - <Apps: "A change that drops support for an earlier software base.">
+        
+        <Libraries: "A change that breaks compatibility with the previous
+        version.">
     * - Minor
       - 3.\ **1**\ .2
       - A new feature within the major version.
     * - Patch
       - 3.1.\ **2**
       - A bug fix within the major or minor version.
-
-Starcraft is released when it achieves development milestones in its product
-lifecycle. It doesn't follow a predefined release cadence.
 
 
 Long-term support
@@ -82,6 +85,9 @@ Long-term support
 Starcraft doesn't have long-term support (LTS) releases. However, we typically
 deliver a compatibility patch shortly after Ubuntu LTS releases to ensure
 continuity.
+
+Starcraft software bases are derived from Ubuntu LTS releases, and their
+development keeps pace with the OS's new releases and support lifecycle.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -1,0 +1,253 @@
+.. _release-notes:
+
+Release notes
+=============
+
+This page lists past release notes for Starcraft, summarising new features, bug
+fixes and backwards-incompatible changes in each version. It also contains the
+release and support policies for Starcraft.
+
+
+Current releases
+----------------
+
+
+<latest release>
+~~~~~~~~~~~~~~~~
+
+- <link to latest release, update, such as 8.2.0>
+- <link to latest release, update, such as 8.1.0>
+- <link to latest release, initial, such as 8.0.0>
+
+
+<parallel release>
+~~~~~~~~~~~~~~~~~~
+
+<If necessary, add guidance and caveats about these older releases, such as
+"Snapcraft 7 is available for building core18 snaps. When building for a newer
+base, use Snapcraft 8.">
+
+- <link to parallel release, update, such as 7.2.0>
+- <link to parallel release, update, such as 7.1.0>
+- <link to parallel release, initial, such as 7.0.0>
+
+
+Past releases
+-------------
+
+
+<past release>
+~~~~~~~~~~~~~~
+
+- <link to past release, update, such as 6.2.0>
+- <link to past release, update, such as 6.1.0>
+- <link to past release, initial, such as 6.0.0>
+
+
+.. _release_policy_and_schedule:
+
+Release policy and schedule
+---------------------------
+
+Canonical is committed to supporting the <"latest major release" or "last two
+major releases"> of Starcraft. <Optional: "We forward-port changes in older
+releases to the latest release, if they're compatible.">
+
+Starcraft is released according to the Semantic Versioning 2.0.0 scheme with
+numbers for major, minor, and patch versions.
+
+.. list-table::
+    :header-rows: 1
+
+    * - Version
+      - Example
+      - Significance
+    * - Major
+      - **3**.1.2
+      - A change that breaks compatibility with the previous version.
+    * - Minor
+      - 3.\ **1**\ .2
+      - A new feature within the major version.
+    * - Patch
+      - 3.1.\ **2**
+      - A bug fix within the major or minor version.
+
+Starcraft is released when it achieves development milestones in its product
+lifecycle. It doesn't follow a predefined release cadence.
+
+
+Long-term support
+-----------------
+
+Starcraft doesn't have long-term support (LTS) releases. However, we typically
+deliver a compatibility patch shortly after Ubuntu LTS releases to ensure
+continuity.
+
+.. toctree::
+   :maxdepth: 1
+
+
+.. release note template:
+
+  Starcraft 1.0 release notes
+  ===========================
+
+  15 October 2024
+
+  Learn about the new features, changes, and fixes introduced in Starcraft 1.0.
+  For information about the Starcraft release cycle, see the
+  :ref:`release_policy_and_schedule`.
+
+
+  Requirements and compatibility
+  ------------------------------
+
+  Starcraft 1.0 requires Python 3.11 or higher.
+
+  <If there are multiple requirements, remove "Python 3.11 or higher" in the
+  previous paragraph and add a separate list here, with the same format of
+  "<package> or higher".>
+
+  For development and testing, Starcraft requires at minimum a <architecture>
+  system or VM with <number>GB RAM.
+
+
+  What's new
+  ----------
+
+  Starcraft 1.0 brings the following features, integrations, and
+  improvements.
+
+
+  <Important change>
+  ~~~~~~~~~~~~~~~~~~
+
+  <Try and stay within these guidelines when writing headings for important
+  changes.>
+
+  +----------------------------------------+------------------------------+-----------------------------------------+
+  | Type of change                         | Heading format               | Example                                 |
+  +========================================+==============================+=========================================+
+  | New feature                            | <Name of feature>            | Snap deltas                             |
+  +----------------------------------------+------------------------------+-----------------------------------------+
+  | Support for technology, or integration | Support for <technology>     | Support for signed commits              |
+  |                                        | <Technology> integration     | Gnome integration                       |
+  +----------------------------------------+------------------------------+-----------------------------------------+
+  | Improvement to existing feature        | <Describe improvement>       | Faster buildset queries                 |
+  |                                        | Improved <aspect of feature> | Improved language of buildset queries   |
+  +----------------------------------------+------------------------------+-----------------------------------------+
+  | Other important update                 | <Describe update>            | Mitigation for Heartbleed vulnerability |
+  +----------------------------------------+------------------------------+-----------------------------------------+
+
+  <Paragraph 1, optional: Briefly cover the previous behaviour or the change in
+  circumstances. For example, "With Ubuntu 24.04 LTS, the Snap Store and App
+  Center now collect public reviews for snaps and assign an averaged score to
+  them to provide users and authors an avenue for discoverability and feedback.">
+
+  <Paragraph 2: Present the new behaviour or feature. In words, *show* what the
+  feature is and make a case for how the reader could benefit from it. Centre the
+  user whenever possible ("you"), and speak on behalf of Canonical ("we"). Prefer
+  general, simple usage over complex applications. Use past tense. For example,
+  "We understand that some authors may not want to have their snaps publicly
+  ranked. If you prefer to disable ranking for your snap, we added the
+  ``feedback`` key in Snapcraft recipes, which contains child keys for
+  controlling many of the rating and feedback features in the store. You can
+  declare ``voting: false`` to disable voting".>
+
+  <Paragraph 3, optional: Provide a call to action. This could take several
+  forms, such as a call to immediately perform a relevant action in Starcraft,
+  solicititation of the reader's feedback on a form or forum, or a link to
+  documentation, demo, blog post, and so on. For example, "See ``:ref:`Manage store
+  profile``` to configure how the public can engage with your snap on the store".>
+
+
+  Minor features
+  --------------
+
+  Starcraft 1.0 brings the following minor changes.
+
+
+  <Feature x>
+  ~~~~~~~~~~~
+
+  <Add a short list of changes to the feature. Keep each item brief and for the
+  most part descriptive. There's little need to sell the change or give a
+  detailed reason. Use past tense. For example, "- Made the error message for
+  ``method()`` more descriptive and recommend a likely remedy.">
+
+
+  Backwards-incompatible changes in Starcraft 1.0
+  -----------------------------------------------
+
+  The following changes are incompatible with previous versions of Starcraft.
+
+
+  <"Removed" or "Disabled"> <feature y>
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  <Paragraph 1, optional: Briefly cover the sequence of events that led to this
+  feature's removal. Use past tense. For example, "SP ABC-123 by the NIST,
+  published in October 2024, showed that algorithm X is no longer considered
+  adequate for protecting data in transit".>
+
+  <Paragraph 2: State precisely what was removed or disabled. Advise on an
+  alternative solution, or state if no alternative exists. If necessary, describe
+  the consequences of the reader's inaction. Link to relevant documentation,
+  standards, or public discussion. For example, "In accordance with the report,
+  Starcraft 1.0 no longer supports encryption algorithm X. As of this release, if
+  you haven't already we highly recommend you immediately switch to encryption
+  algorithm Y to ensure your data stays protected. For more details about this
+  decision and our policy, see ```Security notice on encryption X <>`_`` on the
+  Ubuntu blog.">
+
+
+  Deprecated features in Starcraft 1.0
+  ------------------------------------
+
+  The following features should no longer be used in Starcraft 1.0, and will be removed in Starcraft 1.1.
+
+
+  Deprecated <feature z>
+  ~~~~~~~~~~~~~~~~~~~~~~
+
+  <Use the same format as backwards-incompatible changes, but use future tense to
+  describe what we *intend* and *plan* to do in subsequent releases. Think of
+  this as a promise or commitment to the reader, and be mindful of the trust we
+  want them to place in us. Don't write conjecture or make promises about details
+  that haven't been decided. Include only the decisions that we have set in stone
+  and information we're allowed to disclose at of the release day. Use phrases
+  like "we plan to", or "we are working on", or "we have scheduled development
+  of". End by linking to relevant documentation, standards, or public discussion.
+  For example, "In October 2024, the NIST published SP ABC-123, urging software
+  publishers to cease the use of encryption algorithm X. We are deprecating its
+  usage in this release, and plan to remove it in Starcraft 1.1. For more details
+  about this decision and our policy, see ```Security notice on encryption X <>`_``
+  on the Ubuntu blog.">
+
+
+  Known issues
+  ------------
+
+  The following issues are known and scheduled to be fixed in upcoming patch releases.
+  See individual issue links for any mitigations.
+
+  - <Ticket ID> <Title>
+  - <Ticket ID> <Title>
+
+
+  Fixed bugs and issues
+  ---------------------
+
+  The following issues have been resolved in Starcraft 1.0:
+
+  - <Ticket ID> <Title>
+  - <Ticket ID> <Title>
+
+
+  Contributors
+  ------------
+
+  We would like to share a big thank you to all the people who contributed to this release.
+
+  `@alex <>`_, `@blair <>`_, `@cam <>`_, `@devin <>`_
+

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -1,7 +1,7 @@
-.. _tutorial:
+.. _tutorials:
 
 Tutorials
-*********
+=========
 
 If you want to learn the basics from experience, then our tutorials will help
 you acquire the necessary competencies from real-life examples with fully


### PR DESCRIPTION
Release notes occupy their own top-level section in the documentation TOC.

The template for individual release notes is included as a comment at the end of the index. This follows a pattern set by our changelogs. If there's a better way of including copyable templates, please chime in!

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
CRAFT-3712