### PR TITLE
feat: register the 'slow' mark to pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ line_length = 88
 minversion = "7.0"
 testpaths = "tests"
 xfail_strict = true
+markers = ["slow: slow tests"]
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

The 'slow' mark is used in `test_setuptools.py` and should be present by default if we want to push the adoption of the slow/fast tests dichotomy.  