### PR TITLE
fix: update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,3 @@
 {
-  extends: ["github>canonical/starflow:renovate-base.json5"],
+  extends: ["github>canonical/starflow"],
 }


### PR DESCRIPTION
We've moved to using a default config location for renovate in starflow.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
