### PR TITLE
fix: update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,3 @@
 {
-  extends: ["github>canonical/starflow"],
+  extends: ["github>canonical/starflow:renovate.json5"],
 }


### PR DESCRIPTION
Renovate is way too picky not to have better linters.

Fixes #297 

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
