### PR TITLE
feat: use existing, then snap, then uv pyright

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -49,7 +49,7 @@ setup-tests: install-uv install-build-deps ##- Set up a testing environment with
 	uv sync --frozen
 
 .PHONY: setup-lint
-setup-lint: install-uv install-shellcheck install-lint-build-deps  ##- Set up a linting-only environment
+setup-lint: install-uv install-shellcheck install-pyright install-lint-build-deps  ##- Set up a linting-only environment
 	uv sync --frozen --no-install-workspace --extra lint --extra types
 
 .PHONY: setup-docs
@@ -121,9 +121,7 @@ endif
 ifneq ($(shell which pyright),) # Prefer the system pyright
 	pyright --pythonpath .venv/bin/python
 else
-	# Fix for a bug in npm
-	[ -d "/home/ubuntu/.npm/_cacache" ] && chown -R 1000:1000 "/home/ubuntu/.npm" || true
-	uv run pyright --pythonpath .venv/bin/python
+	uv tool run pyright --pythonpath .venv/bin/python
 endif
 ifneq ($(CI),)
 	@echo ::endgroup::
@@ -232,6 +230,17 @@ else ifneq ($(shell which brew),)
 	uv tool install codespell
 else
 	$(warning Codespell not installed. Please install it yourself.)
+endif
+
+.PHONY: install-pyright
+install-pyright: install-uv
+ifneq ($(shell which pyright),)
+else ifneq ($(shell which snap),)
+	sudo snap install --classic pyright
+else
+    # Workaround for a bug in npm
+	[ -d "$(HOME)/.npm/_cacache" ] && chown -R `id -u`:`id -g` "$(HOME)/.npm" || true
+	uv tool install pyright
 endif
 
 .PHONY: install-ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ lint = [
 ]
 types = [
     "mypy[reports]~=1.13.0",
-    "pyright==1.1.390",
     "types-Pygments",
     "types-colorama",
     "types-setuptools",


### PR DESCRIPTION
This changes the way we get pyright, preferring the snap and no longer having it frozen to a specific version.

As requested by @sergiusens : https://github.com/canonical/craft-store/pull/241#discussion_r1883817892

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
