### PR TITLE
fix: use uv tool run for pre-commit if not global

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -61,7 +61,11 @@ setup-precommit: install-uv  ##- Set up pre-commit hooks in this repository.
 ifeq ($(shell which pre-commit),)
 	uv tool install pre-commit
 endif
+ifeq ($(shell which pre-commit),)
+	uv tool run pre-commit install
+else
 	pre-commit install
+endif
 
 .PHONY: clean
 clean:  ## Clean up the development environment

--- a/common.mk
+++ b/common.mk
@@ -59,9 +59,6 @@ setup-docs: install-uv  ##- Set up a documentation-only environment
 .PHONY: setup-precommit
 setup-precommit: install-uv  ##- Set up pre-commit hooks in this repository.
 ifeq ($(shell which pre-commit),)
-	uv tool install pre-commit
-endif
-ifeq ($(shell which pre-commit),)
 	uv tool run pre-commit install
 else
 	pre-commit install


### PR DESCRIPTION
Issue found here: https://github.com/canonical/craft-store/pull/241#pullrequestreview-2502863941

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
