### PR TITLE
ci: restrict pypi job to amd64

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -38,7 +38,7 @@ jobs:
           path: dist/
   pypi:
     needs: ["source-wheel"]
-    runs-on: [self-hosted, jammy]
+    runs-on: [self-hosted, jammy, amd64]
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write


### PR DESCRIPTION
The `gh-action-pypi-publish` pulls in a docker image to do the actual publishing, and said image is apparently always amd64

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
