### PR TITLE
fix(common.mk): docs ignores

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -163,7 +163,7 @@ lint-docs:  ##- Lint the documentation
 ifneq ($(CI),)
 	@echo ::group::$@
 endif
-	uv run --extra docs sphinx-lint --max-line-length 88 --enable all $(DOCS)
+	uv run --extra docs sphinx-lint --max-line-length 88 --ignore docs/reference/commands --ignore docs/_build --enable all $(DOCS)
 ifneq ($(CI),)
 	@echo ::endgroup::
 endif


### PR DESCRIPTION
See: https://github.com/canonical/charmcraft/pull/2096

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

---
