### PR TITLE
build!: switch from using extras to dependency groups

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 - [ ] Have you followed the guidelines for contributing?
 - [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
-- [ ] Have you successfully run `tox`?
+- [ ] Have you successfully run `make lint && make test`?
 
 ---

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,10 +18,12 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.12"
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+  jobs:
+    post_system_dependencies:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    create_environment:
+      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    install:
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --group docs

--- a/common.mk
+++ b/common.mk
@@ -56,11 +56,11 @@ setup-tests: install-uv install-build-deps ##- Set up a testing environment with
 
 .PHONY: setup-lint
 setup-lint: install-uv install-shellcheck install-pyright install-lint-build-deps  ##- Set up a linting-only environment
-	uv sync --no-install-workspace --extra lint --extra types
+	uv sync --no-install-workspace --group lint --group types
 
 .PHONY: setup-docs
 setup-docs: install-uv  ##- Set up a documentation-only environment
-	uv sync --no-dev --no-install-workspace --extra docs
+	uv sync --no-dev --group docs
 
 .PHONY: setup-precommit
 setup-precommit: install-uv  ##- Set up pre-commit hooks in this repository.
@@ -105,7 +105,7 @@ ifneq ($(CI),)
 endif
 
 .PHONY: lint-codespell
-lint-codespell:  ##- Check spelling with codespell
+lint-codespell: install-codespell  ##- Check spelling with codespell
 ifneq ($(CI),)
 	@echo ::group::$@
 endif
@@ -163,7 +163,7 @@ lint-docs:  ##- Lint the documentation
 ifneq ($(CI),)
 	@echo ::group::$@
 endif
-	uv run --extra docs sphinx-lint --max-line-length 88 --ignore docs/reference/commands --ignore docs/_build --enable all $(DOCS)
+	uv run --group docs sphinx-lint --max-line-length 88 --ignore docs/reference/commands --ignore docs/_build --enable all $(DOCS)
 ifneq ($(CI),)
 	@echo ::endgroup::
 endif
@@ -199,11 +199,11 @@ test-coverage:  ## Generate coverage report
 
 .PHONY: docs
 docs:  ## Build documentation
-	uv run --extra docs sphinx-build -b html -W $(DOCS) $(DOCS)/_build
+	uv run --group docs sphinx-build -b html -W $(DOCS) $(DOCS)/_build
 
 .PHONY: docs-auto
 docs-auto:  ## Build and host docs with sphinx-autobuild
-	uv run --extra docs sphinx-autobuild -b html --open-browser --port=8080 --watch $(PROJECT) -W $(DOCS) $(DOCS)/_build
+	uv run --group docs sphinx-autobuild -b html --open-browser --port=8080 --watch $(PROJECT) -W $(DOCS) $(DOCS)/_build
 
 .PHONY: pack-pip
 pack-pip:  ##- Build packages for pip (sdist, wheel)

--- a/common.mk
+++ b/common.mk
@@ -48,7 +48,7 @@ help: ## Show this help.
 
 .PHONY: setup
 setup: install-uv setup-precommit ## Set up a development environment
-	uv sync --all-extras
+	uv sync --all-groups
 
 .PHONY: setup-tests
 setup-tests: install-uv install-build-deps ##- Set up a testing environment without linters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = ">=3.10"
 [project.scripts]
 starcraft-hello = "starcraft:hello"
 
-[project.optional-dependencies]
+[dependency-groups]
 lint = [
     "yamllint~=1.34",
 ]
@@ -34,11 +34,21 @@ docs = [
     "sphinx-toolbox~=3.5",
     "sphinx-lint==1.0.0",
 ]
+dev = [
+    "build>=0.7.0",
+    "coverage[toml]~=7.4",
+    "pytest~=8.0",
+    "pytest-cov~=6.0",
+    "pytest-mock~=3.12",
+    "mypy[reports]~=1.14.1",
+    "types-Pygments",
+    "types-colorama",
+    "types-setuptools",
+]
 
 [tool.uv]
 constraint-dependencies = [
     # Basic constraints to allow --resolution=lowest
-    "build>=0.7.0",
     "cffi>=1.15",
     "iniconfig>=1.1.0",
     "httplib2>=0.20.0",
@@ -61,17 +71,7 @@ constraint-dependencies = [
     "webencodings>=0.4.0",
     "wheel>=0.38",
 ]
-dev-dependencies = [
-    "build",
-    "coverage[toml]~=7.4",
-    "pytest~=8.0",
-    "pytest-cov~=6.0",
-    "pytest-mock~=3.12",
-    "mypy[reports]~=1.14.1",
-    "types-Pygments",
-    "types-colorama",
-    "types-setuptools",
-]
+
 
 [build-system]
 requires = [

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,6 @@ resolution-markers = [
 
 [manifest]
 constraints = [
-    { name = "build", specifier = ">=0.7.0" },
     { name = "cffi", specifier = ">=1.15" },
     { name = "httplib2", specifier = ">=0.20.0" },
     { name = "iniconfig", specifier = ">=1.1.0" },
@@ -454,7 +453,7 @@ name = "importlib-metadata"
 version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7", size = 55304 }
 wheels = [
@@ -816,15 +815,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
-]
-
-[[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
@@ -974,19 +964,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216 },
-]
-
-[[package]]
-name = "pyright"
-version = "1.1.391"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nodeenv" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/05/4ea52a8a45cc28897edb485b4102d37cbfd5fce8445d679cdeb62bfad221/pyright-1.1.391.tar.gz", hash = "sha256:66b2d42cdf5c3cbab05f2f4b76e8bec8aa78e679bfa0b6ad7b923d9e027cadb2", size = 21965 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/89/66f49552fbeb21944c8077d11834b2201514a56fd1b7747ffff9630f1bd9/pyright-1.1.391-py3-none-any.whl", hash = "sha256:54fa186f8b3e8a55a44ebfa842636635688670c6896dcf6cf4a7fc75062f4d15", size = 18579 },
 ]
 
 [[package]]
@@ -1493,9 +1470,21 @@ wheels = [
 
 [[package]]
 name = "starcraft"
+version = "0.0.post293+g096e54a.d20250123"
 source = { editable = "." }
 
-[package.optional-dependencies]
+[package.dev-dependencies]
+dev = [
+    { name = "build" },
+    { name = "coverage", extra = ["toml"] },
+    { name = "mypy", extra = ["reports"] },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "types-colorama" },
+    { name = "types-pygments" },
+    { name = "types-setuptools" },
+]
 docs = [
     { name = "canonical-sphinx" },
     { name = "sphinx-autobuild" },
@@ -1513,43 +1502,30 @@ types = [
     { name = "types-setuptools" },
 ]
 
-[package.dev-dependencies]
+[package.metadata]
+
+[package.metadata.requires-dev]
 dev = [
-    { name = "build" },
-    { name = "coverage", extra = ["toml"] },
-    { name = "mypy", extra = ["reports"] },
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "pytest-mock" },
+    { name = "build", specifier = ">=0.7.0" },
+    { name = "coverage", extras = ["toml"], specifier = "~=7.4" },
+    { name = "mypy", extras = ["reports"], specifier = "~=1.14.1" },
+    { name = "pytest", specifier = "~=8.0" },
+    { name = "pytest-cov", specifier = "~=6.0" },
+    { name = "pytest-mock", specifier = "~=3.12" },
     { name = "types-colorama" },
     { name = "types-pygments" },
     { name = "types-setuptools" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "canonical-sphinx", marker = "extra == 'docs'", specifier = "~=0.3.0" },
-    { name = "mypy", extras = ["reports"], marker = "extra == 'types'", specifier = "~=1.14.1" },
-    { name = "sphinx-autobuild", marker = "extra == 'docs'", specifier = "~=2024.2" },
-    { name = "sphinx-lint", marker = "extra == 'docs'", specifier = "==1.0.0" },
-    { name = "sphinx-pydantic", marker = "extra == 'docs'", specifier = "==0.1.1" },
-    { name = "sphinx-toolbox", marker = "extra == 'docs'", specifier = "~=3.5" },
-    { name = "types-colorama", marker = "extra == 'types'" },
-    { name = "types-pygments", marker = "extra == 'types'" },
-    { name = "types-setuptools", marker = "extra == 'types'" },
-    { name = "yamllint", marker = "extra == 'lint'", specifier = "~=1.34" },
+docs = [
+    { name = "canonical-sphinx", specifier = "~=0.3.0" },
+    { name = "sphinx-autobuild", specifier = "~=2024.2" },
+    { name = "sphinx-lint", specifier = "==1.0.0" },
+    { name = "sphinx-pydantic", specifier = "==0.1.1" },
+    { name = "sphinx-toolbox", specifier = "~=3.5" },
 ]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "build" },
-    { name = "coverage", extras = ["toml"], specifier = "~=7.4" },
+lint = [{ name = "yamllint", specifier = "~=1.34" }]
+types = [
     { name = "mypy", extras = ["reports"], specifier = "~=1.14.1" },
-    { name = "pyright", specifier = "==1.1.391" },
-    { name = "pytest", specifier = "~=8.0" },
-    { name = "pytest-cov", specifier = "~=6.0" },
-    { name = "pytest-mock", specifier = "~=3.12" },
     { name = "types-colorama" },
     { name = "types-pygments" },
     { name = "types-setuptools" },


### PR DESCRIPTION
This switches from using extras to using dependency groups, now that they are [considered standard](https://packaging.python.org/en/latest/specifications/dependency-groups/#dependency-groups).

It also adjusts the readthedocs build to use uv so that we can use those groups, with a side effect of speeding up the RTD builds (more noticeable here than in bigger projects).

As a drive-by, it also fixes the PR template.


This is marked as a breaking change because the changes to pyproject.toml and common.mk are mutually dependent.