### PR TITLE
fix(common.mk): skip frivolous link checks in lint-docs

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -163,7 +163,10 @@ lint-docs:  ##- Lint the documentation
 ifneq ($(CI),)
 	@echo ::group::$@
 endif
-	uv run --extra docs sphinx-lint --max-line-length 88 --ignore docs/reference/commands --ignore docs/_build --enable all $(DOCS)
+	uv run --extra docs sphinx-lint --max-line-length 88 \
+	--ignore docs/reference/commands --ignore docs/_build \
+	--enable all $(DOCS) \
+	-d missing-underscore-after-hyperlink,missing-space-in-hyperlink
 ifneq ($(CI),)
 	@echo ::endgroup::
 endif


### PR DESCRIPTION
Resolve erroneous link warnings affecting literalref directives. Sphinx-lint will no longer check for spaces before angle brackets (\`\` <>\`\`) or underscores after graves (\`\`_).

The root cause is a bug in our implementation of literalref: https://github.com/canonical/canonical-sphinx-extensions/issues/47

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `uv`?

---
