### PR TITLE
ci: fetch tags on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,6 +19,9 @@ build:
   tools:
     python: "3.12"
   jobs:
+    post_checkout:
+      - git fetch --tags --unshallow # Also fetch tags
+      - git describe # Make sure we get a proper version  
     post_system_dependencies:
       - asdf plugin add uv
       - asdf install uv latest

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,7 +21,6 @@ build:
   jobs:
     post_checkout:
       - git fetch --tags --unshallow # Also fetch tags
-      - git describe # Make sure we get a proper version  
     post_system_dependencies:
       - asdf plugin add uv
       - asdf install uv latest


### PR DESCRIPTION
This is sometimes needs in cases where readthedocs' default clone doesn't include the tags.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
