### PR TITLE
chore: hush some of the linter output

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -13,7 +13,7 @@ else
 	APT := apt-get
 endif
 
-PRETTIER=npm exec --package=prettier -- prettier
+PRETTIER=npm exec --package=prettier -- prettier --log-level warn
 PRETTIER_FILES="**/*.{yaml,yml,json,json5,css,md}"
 
 # By default we should not update the uv lock file here.
@@ -210,7 +210,7 @@ pack-pip:  ##- Build packages for pip (sdist, wheel)
 ifneq ($(CI),)
 	@echo ::group::$@
 endif
-	uv build .
+	uv build --quiet .
 ifneq ($(CI),)
 	@echo ::endgroup::
 endif


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

A couple of the linter tasks were so noisy that previous linting steps would be completely flooded off of the terminal. This PR just quiets it down a bit.