### PR TITLE
chore: remove now-deprecated linter rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,7 +270,6 @@ select = [  # Base linting rule selections.
     "RUF200",  # If ruff fails to parse pyproject.toml...
 ]
 ignore = [
-    "ANN10",  # Type annotations for `self` and `cls`
     #"E203",  # Whitespace before ":"  -- Commented because ruff doesn't currently check E203
     "E501",  # Line too long (reason: black will automatically fix this for us)
     "D105",  # Missing docstring in magic method (reason: magic methods already have definitions)


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

ANN10* ruff rules have been deprecated and removed since they were so commonly ignored. This PR removes it to fix TOML validators complaining.