### PR TITLE
docs(rtd): switch to extensionless URLS

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
+  builder: dirhtml
   configuration: docs/conf.py
 
 # Optionally build your docs in additional formats such as PDF


### PR DESCRIPTION
In keeping with recent changes to Rockcraft and Snapcraft.

---
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

---
