### PR TITLE
feat: ignore jetbrain config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ dmypy.json
 
 # Visual Studio Code
 .vscode/
+
+# JetBrains IDEs
+/.idea/


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

Ignore the `.idea/` directory from PyCharm and other IDEs from JetBrains.

Upstreamed from [snapcraft](https://github.com/canonical/snapcraft/blob/5e21a93fc2ab8bea9e49b0cf941c10adff0f5bf1/.gitignore#L112).