### PR TITLE
build: fix a couple pieces of base pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,16 +2,14 @@
 name = "starcraft"
 description = "The basis for Starcraft team packages"
 dynamic = ["version", "readme"]
-dependencies = [
-
-]
+dependencies = []
 classifiers = [
     "Development Status :: 1 - Planning",
-    "License :: OSI Approved :: GNU General Public License (GPL)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.12",
 ]
+license = "GPL-3.0"
 requires-python = ">=3.10"
 
 [project.scripts]
@@ -46,10 +44,7 @@ dev = [
     "types-colorama",
     "types-setuptools",
 ]
-tics = [
-    "flake8",
-    "pylint",
-]
+tics = ["flake8", "pylint"]
 
 [tool.uv]
 constraint-dependencies = [
@@ -79,14 +74,11 @@ constraint-dependencies = [
 
 
 [build-system]
-requires = [
-    "setuptools>=69.0",
-    "setuptools_scm[toml]>=7.1"
-]
+requires = ["setuptools>=69.0", "setuptools_scm[toml]>=7.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]
-readme = {file = "README.rst"}
+readme = { file = "README.md" }
 
 [tool.setuptools_scm]
 write_to = "starcraft/_version.py"
@@ -144,9 +136,7 @@ omit = ["tests/**"]
 
 [tool.coverage.report]
 skip_empty = true
-exclude_also = [
-    "if (typing\\.)?TYPE_CHECKING:",
-]
+exclude_also = ["if (typing\\.)?TYPE_CHECKING:"]
 
 [tool.pyright]
 strict = ["starcraft"]
@@ -161,10 +151,7 @@ exclude = [
 
 [tool.mypy]
 python_version = "3.10"
-exclude = [
-    "build",
-    "results",
-]
+exclude = ["build", "results"]
 warn_unused_configs = true
 warn_redundant_casts = true
 strict_equality = true
@@ -197,98 +184,105 @@ quote-style = "double"
 [tool.ruff.lint]
 # Follow ST063 - Maintaining and updating linting specifications for updating these.
 # Handy link: https://docs.astral.sh/ruff/rules/
-select = [  # Base linting rule selections.
+select = [ # Base linting rule selections.
     # See the internal document for discussion:
     # https://docs.google.com/document/d/1i1n8pDmFmWi4wTDpk-JfnWCVUThPJiggyPi2DYwBBu4/edit
     # All sections here are stable in ruff and shouldn't randomly introduce
     # failures with ruff updates.
-    "F",  # The rules built into Flake8
-    "E", "W",  # pycodestyle errors and warnings
-    "I",  # isort checking
-    "N",  # PEP8 naming
-    "D",  # Implement pydocstyle checking as well.
-    "UP",  # Pyupgrade - note that some of are excluded below due to Python versions
-    "YTT",  # flake8-2020: Misuse of `sys.version` and `sys.version_info`
-    "ANN",  # Type annotations.
-    "ASYNC",  # Catching blocking calls in async functions
+    "F",     # The rules built into Flake8
+    "E",
+    "W",     # pycodestyle errors and warnings
+    "I",     # isort checking
+    "N",     # PEP8 naming
+    "D",     # Implement pydocstyle checking as well.
+    "UP",    # Pyupgrade - note that some of are excluded below due to Python versions
+    "YTT",   # flake8-2020: Misuse of `sys.version` and `sys.version_info`
+    "ANN",   # Type annotations.
+    "ASYNC", # Catching blocking calls in async functions
     # flake8-bandit: security testing. https://docs.astral.sh/ruff/rules/#flake8-bandit-s
     # https://bandit.readthedocs.io/en/latest/plugins/index.html#complete-test-plugin-listing
-    "S101", "S102",  # assert or exec
-    "S103", "S108",  # File permissions and tempfiles - use #noqa to silence when appropriate.
-    "S104",  # Network binds
-    "S105", "S106", "S107",  # Hardcoded passwords
-    "S110",  # try-except-pass (use contextlib.suppress instead)
-    "S113",  # Requests calls without timeouts
-    "S3",  # Serialising, deserialising, hashing, crypto, etc.
-    "S5",  # Unsafe cryptography or YAML loading.
-    "S602",  # Subprocess call with shell=true
-    "S701",  # jinja2 templates without autoescape
+    "S101",
+    "S102", # assert or exec
+    "S103",
+    "S108", # File permissions and tempfiles - use #noqa to silence when appropriate.
+    "S104", # Network binds
+    "S105",
+    "S106",
+    "S107", # Hardcoded passwords
+    "S110", # try-except-pass (use contextlib.suppress instead)
+    "S113", # Requests calls without timeouts
+    "S3",   # Serialising, deserialising, hashing, crypto, etc.
+    "S5",   # Unsafe cryptography or YAML loading.
+    "S602", # Subprocess call with shell=true
+    "S701", # jinja2 templates without autoescape
     "BLE",  # Do not catch blind exceptions
     "FBT",  # Disallow boolean positional arguments (make them keyword-only)
-    "B0",  # Common mistakes and typos.
-    "A",  # Shadowing built-ins.
+    "B0",   # Common mistakes and typos.
+    "A",    # Shadowing built-ins.
     "COM",  # Trailing commas
-    "C4", # Encourage comprehensions, which tend to be faster than alternatives.
+    "C4",   # Encourage comprehensions, which tend to be faster than alternatives.
     "T10",  # Don't call the debugger in production code
     "ISC",  # Implicit string concatenation that can cause subtle issues
     "ICN",  # Only use common conventions for import aliases.
     "INP",  # Implicit namespace packages
     # flake8-pie: miscellaneous linters (enabled individually because they're not really related)
-    "PIE790",  # Unnecessary pass statement
-    "PIE794",  # Multiple definitions of class field
-    "PIE796",  # Duplicate value in an enum (reasonable to noqa for backwards compatibility)
-    "PIE804",  # Don't use a dict with unnecessary kwargs
-    "PIE807",  # prefer `list` over `lambda: []`
-    "PIE810",  # Use a tuple rather than multiple calls. E.g. `mystr.startswith(("Hi", "Hello"))`
-    "PYI",  # Linting for type stubs.
-    "PT",  # Pytest
-    "Q",  # Consistent quotations
-    "RSE",  # Errors on pytest raises.
-    "RET",  # Simpler logic after return, raise, continue or break
-    "SLF",  # Prevent accessing private class members.
-    "SIM",  # Code simplification
-    "TID",  # Tidy imports
+    "PIE790", # Unnecessary pass statement
+    "PIE794", # Multiple definitions of class field
+    "PIE796", # Duplicate value in an enum (reasonable to noqa for backwards compatibility)
+    "PIE804", # Don't use a dict with unnecessary kwargs
+    "PIE807", # prefer `list` over `lambda: []`
+    "PIE810", # Use a tuple rather than multiple calls. E.g. `mystr.startswith(("Hi", "Hello"))`
+    "PYI",    # Linting for type stubs.
+    "PT",     # Pytest
+    "Q",      # Consistent quotations
+    "RSE",    # Errors on pytest raises.
+    "RET",    # Simpler logic after return, raise, continue or break
+    "SLF",    # Prevent accessing private class members.
+    "SIM",    # Code simplification
+    "TID",    # Tidy imports
     # The team have chosen to only use type-checking blocks when necessary to prevent circular imports.
     # As such, the only enabled type-checking checks are those that warn of an import that needs to be
     # removed from a type-checking block.
     "TC004",  # Remove imports from type-checking guard blocks if used at runtime
     "TC005",  # Delete empty type-checking blocks
-    "ARG",  # Unused arguments
-    "PTH",  # Migrate to pathlib
-    "FIX",  # All TODOs, FIXMEs, etc. should be turned into issues instead.
-    "ERA",  # Don't check in commented out code
-    "PGH",  # Pygrep hooks
-    "PL",  # Pylint
-    "TRY",  # Cleaner try/except,
-    "FLY",  # Detect things that would be better as f-strings.
-    "PERF",  # Catch things that can slow down the application like unnecessary casts to list.
-    "RUF001", "RUF002", "RUF003",  # Ambiguous unicode characters
-    "RUF005",  # Encourages unpacking rather than concatenation
-    "RUF008",  # Do not use mutable default values for dataclass attributes
-    "B035",    # Don't use static keys in dict comprehensions.
-    "RUF013",  # Prohibit implicit Optionals (PEP 484)
-    "RUF100",  # #noqa directive that doesn't flag anything
-    "RUF200",  # If ruff fails to parse pyproject.toml...
+    "ARG",    # Unused arguments
+    "PTH",    # Migrate to pathlib
+    "FIX",    # All TODOs, FIXMEs, etc. should be turned into issues instead.
+    "ERA",    # Don't check in commented out code
+    "PGH",    # Pygrep hooks
+    "PL",     # Pylint
+    "TRY",    # Cleaner try/except,
+    "FLY",    # Detect things that would be better as f-strings.
+    "PERF",   # Catch things that can slow down the application like unnecessary casts to list.
+    "RUF001",
+    "RUF002",
+    "RUF003", # Ambiguous unicode characters
+    "RUF005", # Encourages unpacking rather than concatenation
+    "RUF008", # Do not use mutable default values for dataclass attributes
+    "B035",   # Don't use static keys in dict comprehensions.
+    "RUF013", # Prohibit implicit Optionals (PEP 484)
+    "RUF100", # #noqa directive that doesn't flag anything
+    "RUF200", # If ruff fails to parse pyproject.toml...
 ]
 ignore = [
     #"E203",  # Whitespace before ":"  -- Commented because ruff doesn't currently check E203
-    "E501",  # Line too long (reason: ruff will automatically fix this for us)
-    "D105",  # Missing docstring in magic method (reason: magic methods already have definitions)
-    "D107",  # Missing docstring in __init__ (reason: documented in class docstring)
-    "D203",  # 1 blank line required before class docstring (reason: pep257 default)
-    "D213",  # Multi-line docstring summary should start at the second line (reason: pep257 default)
-    "D215",  # Section underline is over-indented (reason: pep257 default)
-    "A003",  # Class attribute shadowing built-in (reason: Class attributes don't often get bare references)
+    "E501",   # Line too long (reason: ruff will automatically fix this for us)
+    "D105",   # Missing docstring in magic method (reason: magic methods already have definitions)
+    "D107",   # Missing docstring in __init__ (reason: documented in class docstring)
+    "D203",   # 1 blank line required before class docstring (reason: pep257 default)
+    "D213",   # Multi-line docstring summary should start at the second line (reason: pep257 default)
+    "D215",   # Section underline is over-indented (reason: pep257 default)
+    "A003",   # Class attribute shadowing built-in (reason: Class attributes don't often get bare references)
     "SIM117", # Use a single `with` statement with multiple contexts instead of nested `with` statements
-              # (reason: this creates long lines that get wrapped and reduces readability)
+    # (reason: this creates long lines that get wrapped and reduces readability)
 
     # Ignored due to conflicts with ruff's formatter:
     # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
-    "COM812",  # Missing trailing comma - mostly the same, but marginal differences.
-    "ISC001",  # Single-line implicit string concatenation.
+    "COM812", # Missing trailing comma - mostly the same, but marginal differences.
+    "ISC001", # Single-line implicit string concatenation.
 
     # Ignored due to common usage in current code
-    "TRY003",  # Avoid specifying long messages outside the exception class
+    "TRY003", # Avoid specifying long messages outside the exception class
 ]
 
 [tool.ruff.lint.flake8-annotations]
@@ -298,8 +292,8 @@ allow-star-arg-any = true
 strict-checking = true
 
 [tool.ruff.lint.pydocstyle]
-ignore-decorators = [  # Functions with these decorators don't have to have docstrings.
-    "typing.overload",  # Default configuration
+ignore-decorators = [ # Functions with these decorators don't have to have docstrings.
+    "typing.overload", # Default configuration
     # The next four are all variations on override, so child classes don't have to repeat parent classes' docstrings.
     "overrides.override",
     "overrides.overrides",
@@ -315,18 +309,18 @@ max-args = 8
 classmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**.py" = [  # Some things we want for the main project are unnecessary in tests.
-    "D",  # Ignore docstring rules in tests
-    "ANN",  # Ignore type annotations in tests
-    "ARG",  # Allow unused arguments in tests (e.g. for fake functions/methods/classes)
-    "S101",  # Allow assertions in tests
-    "S103", # Allow `os.chmod` setting a permissive mask `0o555` on file or directory
-    "S108", # Allow Probable insecure usage of temporary file or directory
-    "PLR0913",  # Allow many arguments for test functions (useful if we need many fixtures)
-    "PLR2004",  # Allow magic values in tests
-    "SLF",  # Allow accessing private members from tests.
+"tests/**.py" = [ # Some things we want for the main project are unnecessary in tests.
+    "D",       # Ignore docstring rules in tests
+    "ANN",     # Ignore type annotations in tests
+    "ARG",     # Allow unused arguments in tests (e.g. for fake functions/methods/classes)
+    "S101",    # Allow assertions in tests
+    "S103",    # Allow `os.chmod` setting a permissive mask `0o555` on file or directory
+    "S108",    # Allow Probable insecure usage of temporary file or directory
+    "PLR0913", # Allow many arguments for test functions (useful if we need many fixtures)
+    "PLR2004", # Allow magic values in tests
+    "SLF",     # Allow accessing private members from tests.
 ]
 "__init__.py" = [
-    "I001",  # isort leaves init files alone by default, this makes ruff ignore them too.
-    "F401",  # Allows unused imports in __init__ files.
+    "I001", # isort leaves init files alone by default, this makes ruff ignore them too.
+    "F401", # Allows unused imports in __init__ files.
 ]


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

Fixes a couple of pieces of the pyproject that got out of date

- specifying the license in the classifiers field is deprecated, and should instead be an SPDX specifier in the `project.license` field
- adjusted the dynamic README field to reference a markdown instead of a rST file after #365
- cleaning up some whitespace