### PR TITLE
chore: remove obsolete publish target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,6 @@ ifeq ($(shell which snapcraft),)
 endif
 	snapcraft pack
 
-.PHONY: publish
-publish: publish-pypi  ## Publish packages
-
-.PHONY: publish-pypi
-publish-pypi: clean package-pip lint-twine  ##- Publish Python packages to pypi
-	uv tool run twine upload dist/*
-
 # Find dependencies that need installing
 APT_PACKAGES :=
 ifeq ($(wildcard /usr/include/libxml2/libxml/xpath.h),)


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

The `publish` target in the makefile was superseded by PyPI's CI integration, now used in starflow.