### PR TITLE
docs: fail on RTD warnings

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,7 @@ version: 2
 sphinx:
   builder: dirhtml
   configuration: docs/conf.py
+  fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF
 # formats:


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

This addresses a reoccurring and silent problem in Snapcraft where doc warnings would not show up in CI ([source](https://github.com/canonical/snapcraft/pull/5468), [source](https://github.com/canonical/snapcraft/pull/5436)).
