### PR TITLE
chore: remove dynamic readme field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "starcraft"
 description = "The basis for Starcraft team packages"
-dynamic = ["version", "readme"]
+dynamic = ["version"]
 dependencies = []
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -11,6 +11,7 @@ classifiers = [
 ]
 license = "GPL-3.0"
 requires-python = ">=3.10"
+readme = { file = "README.md", content-type = "text/markdown" }
 
 [project.scripts]
 starcraft-hello = "starcraft:hello"
@@ -77,8 +78,6 @@ constraint-dependencies = [
 requires = ["setuptools>=69.0", "setuptools_scm[toml]>=7.1"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools.dynamic]
-readme = { file = "README.md" }
 
 [tool.setuptools_scm]
 write_to = "starcraft/_version.py"


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---

According to the documentation for setuptools' [dynamic fields](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata), setting the README to be dynamic is for when you have multiple files that should be concatenated to create a single README. We don't currently do this in any of our repositories, so there's no reason to use this feature.