### PR TITLE
feat(lint): add uv lockfile linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ include common.mk
 format: format-ruff format-codespell format-prettier  ## Run all automatic formatters
 
 .PHONY: lint
-lint: lint-ruff lint-codespell lint-mypy lint-prettier lint-pyright lint-shellcheck lint-docs lint-twine  ## Run all linters
+lint: lint-ruff lint-codespell lint-mypy lint-prettier lint-pyright lint-shellcheck lint-docs lint-twine lint-uv-lockfile  ## Run all linters
 
 .PHONY: pack
 pack: pack-pip  ## Build all packages

--- a/common.mk
+++ b/common.mk
@@ -149,6 +149,11 @@ ifneq ($(CI),)
 	@echo ::endgroup::
 endif
 
+.PHONY: lint-uv-lockfile
+lint-uv-lockfile: install-uv  ##- Check that uv.lock matches expectations from pyproject.toml
+	unset UV_FROZEN
+	uv lock --check
+
 .PHONY: lint-shellcheck
 lint-shellcheck:  ##- Lint shell scripts
 ifneq ($(CI),)


### PR DESCRIPTION
This came from this discussion: https://github.com/canonical/snapcraft/pull/5529/files#r2121219994

Adds a `lint-uv-lockfile` make target that checks whether uv.lock is valid with the current pyproject.toml. It does not check whether the packages in that file are up to date.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
