### PR TITLE
fix: walk back pre-commit all-files

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -103,7 +103,7 @@ format-codespell:  ##- Fix spelling issues with codespell
 
 .PHONY: format-pre-commit
 format-pre-commit:  ##- Format the entire repository using pre-commit
-	uv tool run pre-commit run --all-files
+	uv tool run pre-commit run
 
 .PHONY: format-prettier
 format-prettier: install-npm  ##- Format files with prettier


### PR DESCRIPTION
Using `--all-files` for pre-commit format affects more files than `make format` would otherwise do.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---
