### PR TITLE
fix(ci): install python3-venv in release workflow

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -14,7 +14,9 @@ jobs:
     runs-on: [self-hosted]
     steps:
       - name: Install uv
-        run: sudo snap install --classic astral-uv
+        run: |
+          sudo snap install --classic astral-uv
+          sudo apt install python3-venv
       - name: Checkout
         uses: actions/checkout@v4
       - name: Fetch tag annotations


### PR DESCRIPTION
If python3-venv isn't installed, setuptools will fail.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
