### PR TITLE
fix: remove conflicting syncs during setup

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -51,11 +51,29 @@ help: ## Show this help.
 	}' | uniq
 
 .PHONY: setup
-setup: install-uv setup-docs setup-lint setup-precommit setup-tests install-build-deps  ## Set up a development environment
+setup: install-uv _setup-docs _setup-lint _setup-tests setup-precommit install-build-deps  ## Set up a development environment
+	uv sync $(UV_TEST_GROUPS) $(UV_LINT_GROUPS) $(UV_DOCS_GROUPS)
+
+.PHONY: setup-docs
+setup-docs: _setup-docs  ##- Set up a documentation-only environment
+	uv sync --no-dev $(UV_DOCS_GROUPS)
+
+.PHONY: _setup-docs
+_setup-docs: install-uv
+
+.PHONY: setup-lint
+setup-lint: _setup-lint  ##- Set up a linting-only environment
+	uv sync $(UV_LINT_GROUPS)
+
+.PHONY: _setup-lint
+_setup-lint: install-uv install-shellcheck install-pyright install-lint-build-deps
 
 .PHONY: setup-tests
-setup-tests: install-uv install-build-deps ##- Set up a testing environment without linters
+setup-tests: _setup-tests ##- Set up a testing environment without linters
 	uv sync $(UV_TEST_GROUPS)
+
+.PHONY: _setup-tests
+_setup-tests: install-uv install-build-deps
 
 .PHONY: setup-tics
 setup-tics: install-uv install-build-deps ##- Set up a testing environment for Tiobe TICS
@@ -64,14 +82,6 @@ setup-tics: install-uv install-build-deps ##- Set up a testing environment for T
 ifneq ($(CI),)
 	echo $(PWD)/.venv/bin >> $(GITHUB_PATH)
 endif
-
-.PHONY: setup-lint
-setup-lint: install-uv install-shellcheck install-pyright install-lint-build-deps  ##- Set up a linting-only environment
-	uv sync $(UV_LINT_GROUPS)
-
-.PHONY: setup-docs
-setup-docs: install-uv  ##- Set up a documentation-only environment
-	uv sync --no-dev $(UV_DOCS_GROUPS)
 
 .PHONY: setup-precommit
 setup-precommit: install-uv  ##- Set up pre-commit hooks in this repository.


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

Prevents conflicting invocations of `uv sync` when running `make setup`. See https://github.com/canonical/starbase/pull/418#issuecomment-3112214042 for context.

* Add intermediate `_setup-*` targets that install requirements without invoking `uv sync`
* Update `setup-*` targets to call said targets and invoke `uv sync`
