### PR TITLE
feat(Makefile): add ty as an optional linter

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -168,7 +168,7 @@ lint-ty: install-ty  ##- Check types with Astral ty (disabled by default)
 ifneq ($(CI),)
 	@echo ::group::$@
 endif
-	ty check $(SOURCES)
+	ty check --python .venv/bin/python $(SOURCES)
 ifneq ($(CI),)
 	@echo ::endgroup::
 endif


### PR DESCRIPTION
This adds the ability to lint a project with ty, but since ty is not yet ready for production, it doesn't make it default.

This allows us to easily check a project with ty if we want without forcing all projects to use it.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
