### PR TITLE
docs: make linkcheck more forgiving

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,6 +122,7 @@ else:
 
 # We have many links on sites that frequently respond with 503s to GitHub runners.
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_retries
+linkcheck_retries = 20
 linkcheck_anchors_ignore = ["#", ":"]
 linkcheck_ignore = [
     # Ignore releases, since we'll include the next release before it exists.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,4 +122,14 @@ else:
 
 # We have many links on sites that frequently respond with 503s to GitHub runners.
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_retries
-linkcheck_retries = 20
+linkcheck_anchors_ignore = ["#", ":"]
+linkcheck_ignore = [
+    # Ignore releases, since we'll include the next release before it exists.
+    "^https://github.com/canonical/[a-z]*craft[a-z-]*/releases/.*",
+    # Entire domains to ignore due to flakiness or issues
+    "^https://www.gnu.org/",
+	"^https://crates.io/",
+	"^https://([\w-]*\.)?npmjs.org",
+	"^https://rsync.samba.org",
+	"^https://ubuntu.com",
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,11 +125,11 @@ else:
 linkcheck_anchors_ignore = ["#", ":"]
 linkcheck_ignore = [
     # Ignore releases, since we'll include the next release before it exists.
-    "^https://github.com/canonical/[a-z]*craft[a-z-]*/releases/.*",
+    r"^https://github.com/canonical/[a-z]*craft[a-z-]*/releases/.*",
     # Entire domains to ignore due to flakiness or issues
-    "^https://www.gnu.org/",
-	"^https://crates.io/",
-	"^https://([\w-]*\.)?npmjs.org",
-	"^https://rsync.samba.org",
-	"^https://ubuntu.com",
+    r"^https://www.gnu.org/",
+    r"^https://crates.io/",
+    r"^https://([\w-]*\.)?npmjs.org",
+    r"^https://rsync.samba.org",
+    r"^https://ubuntu.com",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,3 +119,7 @@ else:
     sitemap_url_scheme = "latest/{link}"
 
 # endregion
+
+# We have many links on sites that frequently respond with 503s to GitHub runners.
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_retries
+linkcheck_retries = 20


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

We get a lot of linkcheck errors in CI. I don't want to disable it as it's very useful, so I want to see if we can make it more forgiving instead.

I've also proposed what I think is a better (more resilient) solution upstream, since that solution will handle it when sites give 500-series errors for a long time.: https://github.com/sphinx-doc/sphinx/issues/13898