### PR TITLE
feat(lint): lint the Github actions with actionlint

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,26 @@
+# Configuration related to self-hosted runner.
+self-hosted-runner:
+  # Labels of self-hosted runner in array of strings.
+  labels:
+    # Architectures
+    - amd64
+    - arm64
+    - ppc64el
+    - riscv64
+    - s390x
+    # Ubuntu releases
+    - focal
+    - jammy
+    - noble
+    - resolute
+    # Sizes
+    - medium
+    - large
+    - xlarge
+    - 2xlarge
+    - 2xlarge-extra
+    # Additional possible labels
+    - edge
+    - tiobe
+    - large-tiobe
+    - 2xlarge-tiobe

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ include common.mk
 format: format-ruff format-codespell format-prettier format-pre-commit  ## Run all automatic formatters
 
 .PHONY: lint
-lint: lint-ruff lint-codespell lint-mypy lint-prettier lint-pyright lint-shellcheck lint-docs lint-twine lint-uv-lockfile  ## Run all linters
+lint: lint-ruff lint-codespell lint-mypy lint-prettier lint-pyright lint-shellcheck lint-docs lint-twine lint-uv-lockfile lint-actions  ## Run all linters
 
 .PHONY: pack
 pack: pack-pip  ## Build all packages

--- a/common.mk
+++ b/common.mk
@@ -66,7 +66,7 @@ setup-lint: _setup-lint  ##- Set up a linting-only environment
 	uv sync $(UV_LINT_GROUPS)
 
 .PHONY: _setup-lint
-_setup-lint: install-uv install-shellcheck install-pyright install-lint-build-deps
+_setup-lint: install-uv install-shellcheck install-pyright install-lint-build-deps install-actionlint
 
 .PHONY: setup-tests
 setup-tests: _setup-tests ##- Set up a testing environment without linters
@@ -200,6 +200,16 @@ ifneq ($(CI),)
 	@echo ::endgroup::
 endif
 
+.PHONY: lint-actions
+lint-actions: install-actionlint  ##- Lint GitHub actions with actionlint
+ifneq ($(CI),)
+	@echo ::group::$@
+endif
+	actionlint
+ifneq ($(CI),)
+	@echo ::endgroup::
+endif
+
 .PHONY: lint-docs
 lint-docs:  ##- Lint the documentation
 ifneq ($(CI),)
@@ -283,6 +293,17 @@ else ifeq ($(OS),Windows_NT)
 	pwsh -c "irm https://astral.sh/uv/install.ps1 | iex"
 else
 	curl -LsSf https://astral.sh/uv/install.sh | sh
+endif
+
+.PHONY: install-actionlint
+install-actionlint:
+ifneq ($(shell which actionlint),)
+else ifneq ($(shell which snap),)
+	sudo snap install actionlint
+else ifneq ($(shell which brew),)
+	brew install actionlint
+else
+	$(warning Actionlint not installed. Please install it yourself.)
 endif
 
 .PHONY: install-codespell


### PR DESCRIPTION
This installs the snap of actionlint (https://github.com/rhysd/actionlint) and adds it as another default linter.

Actionlint catches many common mistakes and has the advantage of running either shellcheck or pyflakes on scripts inside the actions.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] I've updated the relevant release notes.
