### PR TITLE
ci: try to configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  ########################
+  # Main package updates #
+  ########################
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "daily" # Actually "weekdays"
+    exclude-paths:
+      # Test data may reference intentionally selected versions and are never ran in production
+      - "tests/"
+      # Docs dependencies are managed upstream: https://github.com/canonical/sphinx-docs-starter-pack
+      - "docs/"
+    labels:
+      - "PR: Dependencies"
+    assignees:
+      - "@canonical/starcraft-renovators"
+
+  ###########################
+  # Infrequent test updates #
+  ###########################
+  - package-ecosystem: "uv"
+    directory: "tests/"
+    schedule:
+      # Although tests are intentionally excluded from updates, it's still healthy to revisit them
+      # periodically so that they reflect real-world use cases.
+      interval: "quarterly"
+    labels:
+      - "PR: Dependencies"
+    assignees:
+      - "@canonical/starcraft-renovators"


### PR DESCRIPTION
I got tired of stale dependabot PRs that never had any reviewers assigned.

I don't expect this to merge immediately as it's very opinionated, but I'm hoping it can spark a discussion on what settings we _do_ want.

As far as I can tell, there's no way to validate this config other than "yolo", so it shouldn't be propagated until we see it working here. Supposedly it does conform to [the schema](https://www.schemastore.org/dependabot-2.0.json), though.

Key reference: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
