### PR TITLE
docs: format doc version as major.minor

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,8 +20,14 @@ import os
 project = "Starbase"
 author = "Canonical"
 
-# Sidebar documentation title; best kept reasonably short
-html_title = project + " documentation"
+# Format the product name + version for the TOC and HTML title
+# When the product begins versioning, uncomment this block
+# release = <starcraft>.__version__
+# if ".post" in release:
+#     release = "dev"
+# else:
+#     major, minor, *_ = release.split(".")
+#     release = f"{major}.{minor}"
 
 # Copyright string; shown at the bottom of the page
 copyright = "2023-%s, %s" % (datetime.date.today().year, author)


### PR DESCRIPTION
What it says on the tin.

`html_title` isn't needed. It's assigned implicitly.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
