### PR TITLE
build: fix docs-install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROJECT=starcraft
 # COVERAGE_SOURCE="starcraft"
 UV_TEST_GROUPS := "--group=dev"
 UV_DOCS_GROUPS := "--group=docs"
-UV_LINT_GROUPS := "--group=lint" "--group=types"
+UV_LINT_GROUPS := "--group=lint" "--group=types" $(UV_DOCS_GROUPS)
 UV_TICS_GROUPS := "--group=tics"
 
 # If you have dev dependencies that depend on your distro version, uncomment these:

--- a/common.mk
+++ b/common.mk
@@ -284,7 +284,7 @@ docs-auto: docs-install  ##- Render the documentation in a live session
 # Override for `install` target in docs project. We still need the Vale setup, so we
 # run that after the parent docs setup.
 .PHONY: docs-install
-docs-install: setup-docs  ##- Set up documentation packages
+docs-install: _setup-docs  ##- Set up documentation packages
 ifneq ($(CI),)
 	@echo ::group::$@
 endif


### PR DESCRIPTION
Upstream of https://github.com/canonical/snapcraft/pull/6133.

Starbase wasn't broken like Snapcraft was, but this fix makes Starbase more correct and faster.  Previously, `make lint` would uninstall and install dev deps at different points within `make lint`.  Now, it keeps the correct deps installed throughout `make lint`.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
