### PR TITLE
style(lint): ignore FBT001 and FBT002 in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -343,6 +343,8 @@ classmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]
     "PLR0913", # Allow many arguments for test functions (useful if we need many fixtures)
     "PLR2004", # Allow magic values in tests
     "SLF",     # Allow accessing private members from tests.
+    "FBT001",  # Boolean-typed positional arguments are common in tests (e.g. parametrize)
+    "FBT002",  # Boolean default values are common in test helper functions
 ]
 "__init__.py" = [
     "I001", # isort leaves init files alone by default, this makes ruff ignore them too.


### PR DESCRIPTION
Boolean-typed positional arguments and boolean default values are common patterns in tests (e.g. parametrize). This aligns with the rest of the craft-* ecosystem (craft-application, craft-providers, craft-cli).

This change was suggested by  copilot after it examined all the other starcraft repositories for consistency.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
