### PR TITLE
docs: minor clean up and reorg

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ import os
 
 # Project name
 project = "Starbase"
-author = "Canonical"
+author = "Canonical Ltd."
 
 # Format the product name + version for the TOC and HTML title
 # When the product begins versioning, uncomment this block
@@ -30,7 +30,7 @@ author = "Canonical"
 #     release = f"{major}.{minor}"
 
 # Copyright string; shown at the bottom of the page
-copyright = "2023-%s, %s" % (datetime.date.today().year, author)
+copyright = f"2023-{datetime.date.today().year}, {author}"
 
 # Documentation website URL
 ogp_site_url = "https://canonical-starbase.readthedocs-hosted.com/"
@@ -44,7 +44,7 @@ ogp_site_name = project
 ogp_image = "https://assets.ubuntu.com/v1/cc828679-docs_illustration.svg"
 
 # Product favicon; shown in bookmarks, browser tabs, etc.
-# html_favicon = '.sphinx/_static/favicon.png'
+# html_favicon = ".sphinx/_static/favicon.png"
 
 # Dictionary of values to pass into the Sphinx context for all pages:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_context
@@ -52,7 +52,7 @@ html_context = {
     # Product page URL; can be different from product docs URL
     "product_page": "github.com/canonical/starbase",
     # Product tag image; the orange part of your logo, shown in the page header
-    # 'product_tag': '_static/tag.png',
+    # "product_tag": "_static/tag.png",
     "discourse": "",
     # Your Mattermost channel URL
     "mattermost": "https://chat.canonical.com/canonical/channels/documentation",
@@ -61,24 +61,24 @@ html_context = {
     # Your documentation GitHub repository URL
     "github_url": "https://github.com/canonical/starbase",
     # Docs branch in the repo; used in links for viewing the source files
-    'repo_default_branch': 'main',
+    "repo_default_branch": "main",
     # Docs location in the repo; used in links for viewing the source files
     "repo_folder": "/docs/",
     # List contributors on individual pages
     "display_contributors": False,
     # Required for feedback button
-    'github_issues': 'enabled',
+    "github_issues": "enabled",
 }
 
 #html_extra_path = []
 
 # Enable the edit button on pages
 html_theme_options = {
-  'source_edit_link': "https://github.com/canonical/starbase",
+  "source_edit_link": "https://github.com/canonical/starbase",
 }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
-# slug = ''
+# slug = ""
 
 
 #########################
@@ -89,16 +89,16 @@ html_theme_options = {
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
 
 # sphinx-sitemap uses html_baseurl to generate the full URL for each page:
-sitemap_url_scheme = '{link}'
+sitemap_url_scheme = "{link}"
 
 # Include `lastmod` dates in the sitemap:
 # sitemap_show_lastmod = True
 
 # Exclude generated pages from the sitemap:
 sitemap_excludes = [
-    '404/',
-    'genindex/',
-    'search/',
+    "404/",
+    "genindex/",
+    "search/",
 ]
 
 
@@ -121,22 +121,21 @@ rediraffe_redirects = "redirects.txt"
 # Link checker exceptions #
 ###########################
 
-# A regex list of URLs that are ignored by 'make linkcheck'
-linkcheck_anchors_ignore = [
-    "#",
-    ":",
-    r"https://github\.com/.*",
-]
+# Whole sites and individuals URLs to ignore
 linkcheck_ignore = [
-    # Ignore releases, since we'll include the next release before it exists.
-    r"^https://github.com/canonical/[a-z]*craft[a-z-]*/releases/.*",
     # Entire domains to ignore due to flakiness or issues
+    r"^https://github.com",
     r"^https://www.gnu.org/",
     r"^https://crates.io/",
     r"^https://([\w-]*\.)?npmjs.org",
     r"^https://rsync.samba.org",
     r"^https://ubuntu.com",
+    r"^https://matrix.to/#",
+    r"^https://gitlab.gnome.org",
 ]
+
+# Anchor strings to ignore
+linkcheck_anchors_ignore = []
 
 # Give linkcheck multiple tries on failure
 linkcheck_retries = 20
@@ -181,14 +180,14 @@ exclude_patterns = [
     "reuse",
 ]
 
-# Adds custom CSS files, located under 'html_static_path'
+# Adds custom CSS files, located under html_static_path
 html_css_files = [
-    'css/cookie-banner.css'
+    "css/cookie-banner.css"
 ]
 
-# Adds custom JavaScript files, located under 'html_static_path'
+# Adds custom JavaScript files, located under html_static_path
 html_js_files = [
-    'js/bundle.js',
+    "js/bundle.js",
 ]
 
 # Specifies a reST snippet to be appended to each .rst file
@@ -199,8 +198,8 @@ rst_epilog = """
 # disable_feedback_button = True
 
 # Your manpage URL
-# manpages_url = 'https://manpages.ubuntu.com/manpages/{codename}/en/' + \
-#     'man{section}/{page}.{section}.html'
+# manpages_url = "https://manpages.ubuntu.com/manpages/{codename}/en/" + \
+#     "man{section}/{page}.{section}.html"
 
 # Specifies a reST snippet to be prepended to each .rst file
 # This defines a :center: role that centers table cell content.

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -3,7 +3,10 @@
 Explanation
 ===========
 
+Explanations provide a wider perspective of Starcraft. They aid in understanding the
+concepts and relationships of Starcraft as a complete system.
+
 .. toctree::
-    :maxdepth: 1
+    :hidden:
 
     Documentation <documentation>

--- a/docs/how-to-guides/index.rst
+++ b/docs/how-to-guides/index.rst
@@ -1,7 +1,0 @@
-.. _how-to-guides:
-
-How-to guides
-=============
-
-.. toctree::
-   :maxdepth: 1

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -1,0 +1,9 @@
+.. _how-to-guides:
+
+How-to guides
+=============
+
+These pages provide directions for completing tasks and solving problems with Starcraft.
+
+.. toctree::
+    :hidden:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,17 +3,6 @@
 Starcraft
 =========
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   tutorials/index
-   how-to-guides/index
-   reference/index
-   explanation/index
-   release-notes/index
-
-
 .. list-table::
 
     * - | :ref:`Tutorial <tutorials>`
@@ -33,6 +22,19 @@ Starcraft is a member of the Canonical family. It's an open source project
 that warmly welcomes community projects, contributions, suggestions, fixes
 and constructive feedback.
 
-* `Ubuntu Code of Conduct <https://ubuntu.com/community/docs/ethos/code-of-conduct>`_
-* `Canonical Contributor License Agreement
-  <https://ubuntu.com/legal/contributors>`_
+- `Ubuntu Code of Conduct <https://ubuntu.com/community/docs/ethos/code-of-conduct>`__
+- `Canonical Contributor License Agreement <https://ubuntu.com/legal/contributors>`__
+
+
+.. toctree::
+    :hidden:
+
+    tutorials/index
+    how-to/index
+    reference/index
+    explanation/index
+
+.. toctree::
+    :hidden:
+
+    release-notes/index

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -3,5 +3,8 @@
 Reference
 =========
 
+References describe the structure and function of the individual components in
+Starcraft.
+
 .. toctree::
-   :maxdepth: 1
+    :hidden:

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -83,7 +83,7 @@ continuity.
 development keeps pace with the OS's new releases and support lifecycle.>
 
 .. toctree::
-   :maxdepth: 1
+    :hidden:
 
 
 .. release note template:

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -3,9 +3,9 @@
 Tutorials
 =========
 
-If you want to learn the basics from experience, then our tutorials will help
-you acquire the necessary competencies from real-life examples with fully
-reproducible steps.
+If you want to learn the basics from experience, then our tutorials will help you
+acquire the necessary competencies from real-life examples with fully reproducible
+steps.
 
 .. toctree::
-   :maxdepth: 1
+    :hidden:


### PR DESCRIPTION
Apply better patterns:

- Move `docs/how-to-guides` to `docs/how-to`.
- Fix indentation in some boilerplate.
- Add default descriptions to landing pages.
- Fix some ruff linting problems in `conf.py`.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
