### PR TITLE
fix: harden 'make help' for shell portability

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -37,23 +37,11 @@ export UV_FROZEN := true
 .PHONY: help
 help: ## Show this help.
 	@printf "\e[1m%-30s\e[0m | \e[1m%s\e[0m\n" "Target" "Description"
-	printf "\e[2m%-30s + %-41s\e[0m\n" "------------------------------" "------------------------------------------------"
-	egrep -h '^[^:]+\: [^#]*##' $$(echo $(MAKEFILE_LIST) | tac --separator=' ') | sed -e 's/:[^#]*/ /' | sort -V | awk -F '[: ]*' \
-	'{
-		if ($$2 == "##")
-		{
-			$$1=sprintf(" %-28s", $$1);
-			$$2=" | ";
-			print $$0;
-		}
-		else
-		{
-			$$1=sprintf("  └ %-25s", $$1);
-			$$2=" | ";
-			$$3=sprintf(" └ %s", $$3);
-			print $$0;
-		}
-	}' | uniq
+	@printf "\e[2m%-30s + %-41s\e[0m\n" "------------------------------" "------------------------------------------------"
+	@egrep -h '^[^[:space:]][^:]+\:[^#]*##' $$(echo $(MAKEFILE_LIST) | tac --separator=' ' 2>/dev/null || echo $(MAKEFILE_LIST)) | \
+	sed -e 's/:[^#]*/ /' | sort -V | \
+	awk -F '[: ]*' '{ if ($$2 == "##") { $$1=sprintf(" %-28s", $$1); $$2=" | "; print $$0; } else { $$1=sprintf("  └ %-25s", $$1); $$2=" | "; $$3=sprintf(" └ %s", $$3); print $$0; } }' | \
+	uniq
 
 .PHONY: setup
 setup: install-uv _setup-docs _setup-lint _setup-tests setup-precommit install-build-deps  ## Set up a development environment

--- a/common.mk
+++ b/common.mk
@@ -38,9 +38,9 @@ export UV_FROZEN := true
 help: ## Show this help.
 	@printf "\033[1m%-30s\033[0m | \033[1m%s\033[0m\n" "Target" "Description"
 	@printf "\033[2m%-30s + %-41s\033[0m\n" "------------------------------" "------------------------------------------------"
-	@grep -Eh '^[^[:space:]][^:]*\:[^#]*##' $$(echo $(MAKEFILE_LIST) | tac --separator=' ' 2>/dev/null || echo $(MAKEFILE_LIST)) | \
+	@cat $$(echo $(MAKEFILE_LIST) | tac --separator=' ' 2>/dev/null || echo $(MAKEFILE_LIST)) | grep -E '^[^[:space:]][^:]*\:[^#]*##' | \
 	sed -e 's/:[^#]*/ /' | sort -V | \
-	awk -F '[: ]*' '{ if ($$2 == "##") { $$1=sprintf(" %-28s", $$1); $$2=" | "; print $$0; } else { $$1=sprintf("  └ %-25s", $$1); $$2=" | "; $$3=sprintf(" └ %s", $$3); print $$0; } }' | \
+	awk -F '[: ]+' '{ if ($$2 == "##") { $$1=sprintf(" %-28s", $$1); $$2=" | "; print $$0; } else { $$1=sprintf("  └ %-25s", $$1); $$2=" | "; $$3=sprintf(" └ %s", $$3); print $$0; } }' | \
 	uniq
 
 .PHONY: setup

--- a/common.mk
+++ b/common.mk
@@ -38,7 +38,7 @@ export UV_FROZEN := true
 help: ## Show this help.
 	@printf "\e[1m%-30s\e[0m | \e[1m%s\e[0m\n" "Target" "Description"
 	printf "\e[2m%-30s + %-41s\e[0m\n" "------------------------------" "------------------------------------------------"
-	egrep '^[^:]+\: [^#]*##' $$(echo $(MAKEFILE_LIST) | tac --separator=' ') | sed -e 's/:[^#]*/ /' | sort -V | awk -F '[: ]*' \
+	egrep -h '^[^:]+\: [^#]*##' $$(echo $(MAKEFILE_LIST) | tac --separator=' ') | sed -e 's/:[^#]*/ /' | sort -V | awk -F '[: ]*' \
 	'{
 		if ($$2 == "##")
 		{

--- a/common.mk
+++ b/common.mk
@@ -36,8 +36,8 @@ export UV_FROZEN := true
 
 .PHONY: help
 help: ## Show this help.
-	@printf "\e[1m%-30s\e[0m | \e[1m%s\e[0m\n" "Target" "Description"
-	@printf "\e[2m%-30s + %-41s\e[0m\n" "------------------------------" "------------------------------------------------"
+	@printf "\033[1m%-30s\033[0m | \033[1m%s\033[0m\n" "Target" "Description"
+	@printf "\033[2m%-30s + %-41s\033[0m\n" "------------------------------" "------------------------------------------------"
 	@egrep -h '^[^[:space:]][^:]+\:[^#]*##' $$(echo $(MAKEFILE_LIST) | tac --separator=' ' 2>/dev/null || echo $(MAKEFILE_LIST)) | \
 	sed -e 's/:[^#]*/ /' | sort -V | \
 	awk -F '[: ]*' '{ if ($$2 == "##") { $$1=sprintf(" %-28s", $$1); $$2=" | "; print $$0; } else { $$1=sprintf("  └ %-25s", $$1); $$2=" | "; $$3=sprintf(" └ %s", $$3); print $$0; } }' | \

--- a/common.mk
+++ b/common.mk
@@ -38,7 +38,7 @@ export UV_FROZEN := true
 help: ## Show this help.
 	@printf "\033[1m%-30s\033[0m | \033[1m%s\033[0m\n" "Target" "Description"
 	@printf "\033[2m%-30s + %-41s\033[0m\n" "------------------------------" "------------------------------------------------"
-	@egrep -h '^[^[:space:]][^:]+\:[^#]*##' $$(echo $(MAKEFILE_LIST) | tac --separator=' ' 2>/dev/null || echo $(MAKEFILE_LIST)) | \
+	@grep -Eh '^[^[:space:]][^:]*\:[^#]*##' $$(echo $(MAKEFILE_LIST) | tac --separator=' ' 2>/dev/null || echo $(MAKEFILE_LIST)) | \
 	sed -e 's/:[^#]*/ /' | sort -V | \
 	awk -F '[: ]*' '{ if ($$2 == "##") { $$1=sprintf(" %-28s", $$1); $$2=" | "; print $$0; } else { $$1=sprintf("  └ %-25s", $$1); $$2=" | "; $$3=sprintf(" └ %s", $$3); print $$0; } }' | \
 	uniq


### PR DESCRIPTION
I believe this fixes #538 

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
