### PR TITLE
feat: add agents files

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -123,12 +123,16 @@ TODO
 
 7. Rewrite the README.
 
-8. If a Diataxis quadrant (tutorials, how-tos, references, explanations) doesn't yet
+8. Follow the instructions in the appropriate agents template - `AGENTS.app.md` for
+   craft apps and `AGENTS.lib.md` for craft libraries. Other projects (like starflow)
+   should start with `AGENTS.app.md` and customize it as-needed.
+
+9. If a Diataxis quadrant (tutorials, how-tos, references, explanations) doesn't yet
    have content, remove its landing page from the TOC and delete its card in
    `docs/index.rst`. You can re-index it when at least one document has been produced
    for it.
 
-9. Register the product's documentation on our custom domain on [Read the Docs for
+10. Register the product's documentation on our custom domain on [Read the Docs for
    Business](https://library.canonical.com/documentation/publish-on-read-the-docs)
 
-10. Delete `.github/README.md`.
+11. Delete `.github/README.md`, `AGENTS.app.md`, and `AGENTS.lib.md`.

--- a/.github/README.md
+++ b/.github/README.md
@@ -133,6 +133,6 @@ TODO
    for it.
 
 10. Register the product's documentation on our custom domain on [Read the Docs for
-   Business](https://library.canonical.com/documentation/publish-on-read-the-docs)
+    Business](https://library.canonical.com/documentation/publish-on-read-the-docs)
 
 11. Delete `.github/README.md`, `AGENTS.app.md`, and `AGENTS.lib.md`.

--- a/.github/README.md
+++ b/.github/README.md
@@ -62,6 +62,11 @@ TODO
        as you can to the structure of the [Security policy template](SECURITY.md). Be
        sure to follow the comments in the template closely.
 
+    6. `AGENTS.md` - Follow the instructions in the appropriate agents template -
+       `AGENTS.app.md` for craft apps and `AGENTS.lib.md` for craft libraries. Other
+       projects (like starflow) should start with `AGENTS.app.md` and customize it
+       as-needed.
+
 4. Run all the linters with `make lint`.
     1. `mypy`:
         - Mypy checks the same things as `ruff`'s `ANNXXX` checks, but `ruff`'s `noqa`
@@ -135,4 +140,4 @@ TODO
 10. Register the product's documentation on our custom domain on [Read the Docs for
     Business](https://library.canonical.com/documentation/publish-on-read-the-docs)
 
-11. Delete `.github/README.md`, `AGENTS.app.md`, and `AGENTS.lib.md`.
+11. Delete `.github/README.md`.

--- a/AGENTS.app.md
+++ b/AGENTS.app.md
@@ -43,10 +43,10 @@ Starbase is built on the following craft libraries:
 | `craft-providers`   | Build environment manager for LXD and Multipass                                               |
 | `craft-store`       | Store API client: upload, release, track management                                           |
 
-The source code for these libraries are at https://github.com/canonical/<library>.
+The source code for these libraries is at https://github.com/canonical/<library>.
 
 These libraries are used by other craft apps, including but not limited to Charmcraft,
-Debcraft, Imagecraft, Rockcraft, and Snapcraft. The source code for these apps are at
+Debcraft, Imagecraft, Rockcraft, and Snapcraft. The source code for these apps is at
 https://github.com/canonical/<app>.
 
 Fixes or features that are generic or would benefit other craft apps must be made in the
@@ -70,7 +70,7 @@ uv run pytest tests/unit/path/to/test_file.py::test_name  # run a specific test
 ```
 
 End-to-end tests (`tests/spread/`) use [spread](https://github.com/canonical/spread/)
-and require additional set up to run locally.
+and require additional setup to run locally.
 
 ### Formatting and linting
 

--- a/AGENTS.app.md
+++ b/AGENTS.app.md
@@ -1,0 +1,116 @@
+# Agents
+
+<!-- Note to developers: This file is intended for apps based on Craft Application.
+
+     To complete this AGENTS.md file for your app:
+     1. Replace instances of "Starbase" and "starbase" with the app name.
+     2. Complete the 'TODO' section in the overview.
+     3. Rename to AGENTS.md.
+     4. Delete AGENTS.lib.md
+     5. Delete this comment.
+
+    General guidelines on agents files:
+     - Keep it brief. This file will be in the context of every prompt and increases the
+       number of reasoning tokens, so it should be as short as possible.
+     - Ask the LLM to generate an agents file and ensure your agents file doesn't
+       include that information.
+         - LLMs (as of 2026) produce agents files that actually hinder performance.
+           Instead, an agents file should be instructing things that:
+             - couldn't be quickly deduced by a senior developer,
+             - are very important, or
+             - are often missed by LLMs.
+     - Mention specific tooling. For example, mentioning `uv` will dramatically increase
+       the odds that the agent will use uv.
+    -->
+
+## Overview
+
+`canonical/starbase` is a Python CLI tool for (TODO: add an inline explanation of the
+app).
+
+## Craft apps and libraries
+
+Starbase is built on the following craft libraries:
+
+| Package             | Role                                                                                          |
+| ------------------- | --------------------------------------------------------------------------------------------- |
+| `craft-application` | Application framework: CLI lifecycle, configuration, service management, remote build support |
+| `craft-archives`    | Repository and package archive management (apt sources, keyrings)                             |
+| `craft-cli`         | Terminal output, progress reporting, error formatting                                         |
+| `craft-grammar`     | Architecture and platform-conditional YAML in project files                                   |
+| `craft-parts`       | Part lifecycle (pull, build, overlay, stage, prime) steps, plugins                            |
+| `craft-platforms`   | Platform and architecture abstractions                                                        |
+| `craft-providers`   | Build environment manager for LXD and Multipass                                               |
+| `craft-store`       | Store API client: upload, release, track management                                           |
+
+The source code for these libraries are at https://github.com/canonical/<library>.
+
+These libraries are used by other craft apps, including but not limited to Charmcraft,
+Debcraft, Imagecraft, Rockcraft, and Snapcraft. The source code for these apps are at
+https://github.com/canonical/<app>.
+
+Fixes or features that are generic or would benefit other craft apps must be made in the
+correct craft library. Overriding an upstream function to fix a bug in the library isn't
+acceptable.
+
+## Development
+
+Starbase uses [uv](https://docs.astral.sh/uv/) for dependency management.
+
+```bash
+make setup          # Install all deps
+```
+
+### Running tests
+
+```bash
+make test           # Full test suite
+make test-fast      # Fast tests only
+uv run pytest tests/unit/path/to/test_file.py::test_name  # run a specific test
+```
+
+End-to-end tests (`tests/spread/`) use [spread](https://github.com/canonical/spread/)
+and require additional set up to run locally.
+
+### Formatting and linting
+
+```bash
+make format
+make lint
+```
+
+### Documentation
+
+Documentation uses the [Diátaxis](https://diataxis.fr) framework and the
+[Sphinx Stack](https://github.com/canonical/sphinx-stack).
+
+```bash
+make setup-docs
+make docs
+make lint-docs
+```
+
+## Practices
+
+- Backward compatibility is a hard requirement. Existing projects must continue to
+  build successfully without requiring user modifications. Changes that alter behavior,
+  configuration, APIs, defaults, or validation rules must be opt-in or gated behind a
+  newer base. When modifying business logic, verify that existing behavior is preserved
+  and explain how you verified it.
+- Make the smallest safe change necessary to resolve the issue. Avoid unrelated bug
+  fixes, opportunistic cleanup, and refactoring unless required. The right amount of
+  complexity is the minimum needed for the current task.
+- Never speculate about code you haven't inspected.
+- Follow the project's existing conventions regarding style, docstrings, logging, and
+  comments.
+- Update relevant documentation and release notes to reflect code changes.
+
+## Processes
+
+- If you're contributing to a specific release, target the upstream
+  `hotfix/<major.minor>` branch. Otherwise, target the `main` branch.
+- Commit headers are no more than 80 characters, follow [Conventional
+  Commits](https://www.conventionalcommits.org/en/v1.0.0/), and use the following types:
+    - ci, build, feat, fix, perf, refactor, style, test, docs, chore
+- Always run `make format`, `make lint`, and `make test-fast` before completing your
+  work.

--- a/AGENTS.app.md
+++ b/AGENTS.app.md
@@ -47,7 +47,7 @@ The source code for these libraries is at https://github.com/canonical/<library>
 
 These libraries are used by other craft apps, including but not limited to Charmcraft,
 Debcraft, Imagecraft, Rockcraft, and Snapcraft. The source code for these apps is at
-https://github.com/canonical/<app>.
+https://github.com/canonical/<app-name-in-lowercase>.
 
 Fixes or features that are generic or would benefit other craft apps must be made in the
 correct craft library. Overriding an upstream function to fix a bug in the library isn't
@@ -70,7 +70,10 @@ uv run pytest tests/unit/path/to/test_file.py::test_name  # run a specific test
 ```
 
 End-to-end tests (`tests/spread/`) use [spread](https://github.com/canonical/spread/)
-and require additional setup to run locally.
+and require additional setup to run locally. Spread tests should be run for
+comprehensive changes or changes that can't be completely verified with unit and
+integration tests. Spread tests are expensive to run, so extend existing tests when
+appropriate.
 
 ### Formatting and linting
 
@@ -95,7 +98,7 @@ make lint-docs
 
 ## Practices
 
-- Backward compatibility is a hard requirement. Existing projects must continue to
+- Backward compatibility is a **hard requirement**. Existing projects must continue to
   build successfully without requiring user modifications. Changes that alter behavior,
   configuration, APIs, defaults, or validation rules must be opt-in or gated behind a
   newer base. When modifying business logic, verify that existing behavior is preserved
@@ -106,14 +109,17 @@ make lint-docs
   fixes, opportunistic cleanup, and refactoring unless required. The right amount of
   complexity is the minimum needed for the current task.
 - Never speculate about code you haven't inspected.
-- Follow the project's existing conventions regarding style, docstrings, logging, and
-  comments.
+- Follow the project's existing conventions regarding style, docstrings, logging,
+  comments, and testing.
+- Comments should explain complex business logic, non-obvious algorithms, regex, and
+  other "gotchas". Comments should brief, explain "why" not "how", and be helpful for
+  future maintainers.
 - Update relevant documentation and release notes to reflect code changes.
 
 ## Processes
 
 - If you're contributing to a specific release, target the upstream
-  `hotfix/<major.minor>` branch. Otherwise, target the `main` branch.
+  `hotfix/<major.minor>` branch, if it exists. Otherwise, target the `main` branch.
 - Commit headers are no more than 80 characters, follow [Conventional
   Commits](https://www.conventionalcommits.org/en/v1.0.0/), and use the following types:
     - ci, build, feat, fix, perf, refactor, style, test, docs, chore

--- a/AGENTS.app.md
+++ b/AGENTS.app.md
@@ -81,8 +81,11 @@ make lint
 
 ### Documentation
 
-Documentation uses the [Diátaxis](https://diataxis.fr) framework and the
-[Sphinx Stack](https://github.com/canonical/sphinx-stack).
+Documentation uses the [Diátaxis](https://diataxis.fr) framework
+and the [Sphinx Stack](https://github.com/canonical/sphinx-stack).
+All documentation must follow the [Starcraft style
+guide](https://documentation.ubuntu.com/starflow/latest/how-to/starcraft-style-guide/)
+and the overall [Canonical style guide](https://documentation.ubuntu.com/style-guide/).
 
 ```bash
 make setup-docs
@@ -97,6 +100,8 @@ make lint-docs
   configuration, APIs, defaults, or validation rules must be opt-in or gated behind a
   newer base. When modifying business logic, verify that existing behavior is preserved
   and explain how you verified it.
+    - Experimental features and development bases (`build-base: devel`) are not subject
+      to this requirement.
 - Make the smallest safe change necessary to resolve the issue. Avoid unrelated bug
   fixes, opportunistic cleanup, and refactoring unless required. The right amount of
   complexity is the minimum needed for the current task.

--- a/AGENTS.lib.md
+++ b/AGENTS.lib.md
@@ -78,8 +78,11 @@ make lint
 
 ### Documentation
 
-Documentation uses the [Diátaxis](https://diataxis.fr) framework and the
-[Sphinx Stack](https://github.com/canonical/sphinx-stack).
+Documentation uses the [Diátaxis](https://diataxis.fr) framework
+and the [Sphinx Stack](https://github.com/canonical/sphinx-stack).
+All documentation must follow the [Starcraft style
+guide](https://documentation.ubuntu.com/starflow/latest/how-to/starcraft-style-guide/)
+and the overall [Canonical style guide](https://documentation.ubuntu.com/style-guide/).
 
 ```bash
 make setup-docs

--- a/AGENTS.lib.md
+++ b/AGENTS.lib.md
@@ -4,7 +4,7 @@
 
      To complete this AGENTS.md file for your library:
      1. Replace instances of "Starbase" and "starbase" with the library name.
-     2. Complete the 'TODO' section in the overview.
+     2. Complete the 'TODO' sections.
      3. Rename to AGENTS.md.
      4. Delete AGENTS.app.md.
      5. Delete this comment.
@@ -31,7 +31,7 @@ library).
 ## Craft apps and libraries
 
 Starbase is used by craft apps, including but not limited to Charmcraft, Debcraft,
-Imagecraft, Rockcraft, and Snapcraft. The source code for these apps are at
+Imagecraft, Rockcraft, and Snapcraft. The source code for these apps is at
 https://github.com/canonical/<app>.
 
 Craft apps use starbase in conjunction with the following craft libraries:
@@ -47,7 +47,7 @@ Craft apps use starbase in conjunction with the following craft libraries:
 | `craft-providers`   | Build environment manager for LXD and Multipass                                               |
 | `craft-store`       | Store API client: upload, release, track management                                           |
 
-The source code for these libraries are at https://github.com/canonical/<library>.
+The source code for these libraries is at https://github.com/canonical/<library>.
 
 ## Development
 
@@ -65,8 +65,9 @@ make test-fast      # Fast tests only
 uv run pytest tests/unit/path/to/test_file.py::test_name  # run a specific test
 ```
 
+(TODO: delete this section if there are no spread tests)
 End-to-end tests (`tests/spread/`) use [spread](https://github.com/canonical/spread/)
-and require additional set up to run locally.
+and require additional setup to run locally.
 
 ### Formatting and linting
 

--- a/AGENTS.lib.md
+++ b/AGENTS.lib.md
@@ -1,0 +1,112 @@
+# Agents
+
+<!-- Note to developers: This file is intended for craft libraries.
+
+     To complete this AGENTS.md file for your library:
+     1. Replace instances of "Starbase" and "starbase" with the library name.
+     2. Complete the 'TODO' section in the overview.
+     3. Rename to AGENTS.md.
+     4. Delete AGENTS.app.md.
+     5. Delete this comment.
+
+    Some guidelines:
+     - Keep it brief. This file will be in the context of every prompt and increases the
+       number of reasoning tokens, so it should be as short as possible.
+     - Ask the LLM to generate an agents file and ensure your agents file doesn't
+       include that information.
+         - LLMs (as of 2026) produce agents files that actually hinder performance.
+           Instead, an agents file should be instructing things that:
+             - couldn't be quickly deduced by a senior developer,
+             - are very important, or
+             - are often missed by LLMs.
+     - Mention specific tooling. For example, mentioning `uv` will dramatically increase
+       the odds that the agent will use uv.
+    -->
+
+## Overview
+
+`canonical/starbase` is a Python library for (TODO: add an inline explanation of the
+library).
+
+## Craft apps and libraries
+
+Starbase is used by craft apps, including but not limited to Charmcraft, Debcraft,
+Imagecraft, Rockcraft, and Snapcraft. The source code for these apps are at
+https://github.com/canonical/<app>.
+
+Craft apps use starbase in conjunction with the following craft libraries:
+
+| Package             | Role                                                                                          |
+| ------------------- | --------------------------------------------------------------------------------------------- |
+| `craft-application` | Application framework: CLI lifecycle, configuration, service management, remote build support |
+| `craft-archives`    | Repository and package archive management (apt sources, keyrings)                             |
+| `craft-cli`         | Terminal output, progress reporting, error formatting                                         |
+| `craft-grammar`     | Architecture and platform-conditional YAML in project files                                   |
+| `craft-parts`       | Part lifecycle (pull, build, overlay, stage, prime) steps, plugins                            |
+| `craft-platforms`   | Platform and architecture abstractions                                                        |
+| `craft-providers`   | Build environment manager for LXD and Multipass                                               |
+| `craft-store`       | Store API client: upload, release, track management                                           |
+
+The source code for these libraries are at https://github.com/canonical/<library>.
+
+## Development
+
+Starbase uses [uv](https://docs.astral.sh/uv/) for dependency management.
+
+```bash
+make setup          # Install all deps
+```
+
+### Running tests
+
+```bash
+make test           # Full test suite
+make test-fast      # Fast tests only
+uv run pytest tests/unit/path/to/test_file.py::test_name  # run a specific test
+```
+
+End-to-end tests (`tests/spread/`) use [spread](https://github.com/canonical/spread/)
+and require additional set up to run locally.
+
+### Formatting and linting
+
+```bash
+make format
+make lint
+```
+
+### Documentation
+
+Documentation uses the [Diátaxis](https://diataxis.fr) framework and the
+[Sphinx Stack](https://github.com/canonical/sphinx-stack).
+
+```bash
+make setup-docs
+make docs
+make lint-docs
+```
+
+## Practices
+
+- Backward compatibility is a hard requirement. Apps using this library must continue to
+  build successfully without requiring user modifications. Changes that alter behavior,
+  configuration, APIs, defaults, or validation rules must be opt-in. When modifying
+  business logic, verify that existing behavior is preserved and explain how you
+  verified it.
+- Make the smallest safe change necessary to resolve the issue. Avoid unrelated bug
+  fixes, opportunistic cleanup, and refactoring unless required. The right amount of
+  complexity is the minimum needed for the current task.
+- Never speculate about code you haven't inspected.
+- Follow the project's existing conventions regarding style, docstrings, logging, and
+  comments.
+- Update relevant documentation and release notes to reflect code changes.
+
+## Processes
+
+- If you're contributing to a specific release, target the upstream
+  `hotfix/<major.minor>` branch. Otherwise, target the `main` branch.
+- Commit headers are no more than 80 characters, follow [Conventional
+  Commits](https://www.conventionalcommits.org/en/v1.0.0/), and use the following types:
+    - ci, build, feat, fix, perf, refactor, style, test, docs, chore
+- Always run `make format`, `make lint`, and `make test-fast` before completing your
+  work.

--- a/AGENTS.lib.md
+++ b/AGENTS.lib.md
@@ -32,7 +32,7 @@ library).
 
 Starbase is used by craft apps, including but not limited to Charmcraft, Debcraft,
 Imagecraft, Rockcraft, and Snapcraft. The source code for these apps is at
-https://github.com/canonical/<app>.
+https://github.com/canonical/<app-name-in-lowercase>.
 
 Craft apps use starbase in conjunction with the following craft libraries:
 
@@ -67,7 +67,10 @@ uv run pytest tests/unit/path/to/test_file.py::test_name  # run a specific test
 
 (TODO: delete this section if there are no spread tests)
 End-to-end tests (`tests/spread/`) use [spread](https://github.com/canonical/spread/)
-and require additional setup to run locally.
+and require additional setup to run locally. Spread tests should be run for
+comprehensive changes or changes that can't be completely verified with unit and
+integration tests. Spread tests are expensive to run, so extend existing tests when
+appropriate.
 
 ### Formatting and linting
 
@@ -92,23 +95,26 @@ make lint-docs
 
 ## Practices
 
-- Backward compatibility is a hard requirement. Apps using this library must continue to
-  build successfully without requiring user modifications. Changes that alter behavior,
-  configuration, APIs, defaults, or validation rules must be opt-in. When modifying
-  business logic, verify that existing behavior is preserved and explain how you
-  verified it.
+- Backward compatibility is a **hard requirement**. Apps using this library must
+  continue to build successfully without requiring user modifications. Changes that
+  alter behavior, configuration, APIs, defaults, or validation rules must be opt-in.
+  When modifying business logic, verify that existing behavior is preserved and explain
+  how you verified it.
 - Make the smallest safe change necessary to resolve the issue. Avoid unrelated bug
   fixes, opportunistic cleanup, and refactoring unless required. The right amount of
   complexity is the minimum needed for the current task.
 - Never speculate about code you haven't inspected.
-- Follow the project's existing conventions regarding style, docstrings, logging, and
-  comments.
+- Follow the project's existing conventions regarding style, docstrings, logging,
+  comments, and testing.
+- Comments should explain complex business logic, non-obvious algorithms, regex, and
+  other "gotchas". Comments should brief, explain "why" not "how", and be helpful for
+  future maintainers.
 - Update relevant documentation and release notes to reflect code changes.
 
 ## Processes
 
 - If you're contributing to a specific release, target the upstream
-  `hotfix/<major.minor>` branch. Otherwise, target the `main` branch.
+  `hotfix/<major.minor>` branch, if it exists. Otherwise, target the `main` branch.
 - Commit headers are no more than 80 characters, follow [Conventional
   Commits](https://www.conventionalcommits.org/en/v1.0.0/), and use the following types:
     - ci, build, feat, fix, perf, refactor, style, test, docs, chore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ and test infrastructure.
 This repository is an upstream repository for more than 20 Starcraft projects, such as
 Snapcraft, Rockcraft, craft-application, and craft-parts.
 
-The source code for these projects are at https://github.com/canonical/<project>.
+The source code for these projects is at https://github.com/canonical/<project>.
 
 Repos that use starbase track it as a git remote named `starbase` and periodically merge
 changes from `starbase/main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# Agents
+
+## Overview
+
+`canonical/starbase` is a shared scaffold/base repository for the Starcraft team. It
+contains common build tooling, CI workflows, linting configs, documentation templates,
+and test infrastructure.
+
+## Starcraft projects
+
+This repository is an upstream repository for more than 20 Starcraft projects, such as
+Snapcraft, Rockcraft, craft-application, and craft-parts.
+
+The source code for these projects are at https://github.com/canonical/<project>.
+
+Repos that use starbase track it as a git remote named `starbase` and periodically merge
+changes from `starbase/main`.
+
+## Development
+
+Starbase uses [uv](https://docs.astral.sh/uv/) for dependency management.
+
+```bash
+make setup          # Install all deps
+```
+
+### Running tests
+
+```bash
+make test           # Full test suite
+make test-fast      # Fast tests only
+uv run pytest tests/unit/path/to/test_file.py::test_name  # run a specific test
+```
+
+### Formatting and linting
+
+```bash
+make format
+make lint
+```
+
+### Documentation
+
+Documentation uses the [Diátaxis](https://diataxis.fr) framework and the
+[Sphinx Stack](https://github.com/canonical/sphinx-stack).
+
+```bash
+make setup-docs
+make docs
+make lint-docs
+```
+
+## Practices
+
+- Make the smallest safe change necessary to resolve the issue. Avoid unrelated bug
+  fixes, opportunistic cleanup, and refactoring unless required. The right amount of
+  complexity is the minimum needed for the current task.
+- Never speculate about code you haven't inspected.
+- Follow the project's existing conventions regarding style, docstrings, logging, and
+  comments.
+- Update relevant documentation and release notes to reflect code changes.
+
+## Processes
+
+- Commit headers are no more than 80 characters, follow [Conventional
+  Commits](https://www.conventionalcommits.org/en/v1.0.0/), and use the following types:
+    - ci, build, feat, fix, perf, refactor, style, test, docs, chore
+- Always run `make format`, `make lint`, and `make test-fast` before completing your
+  work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,11 @@ make lint
 
 ### Documentation
 
-Documentation uses the [Diátaxis](https://diataxis.fr) framework and the
-[Sphinx Stack](https://github.com/canonical/sphinx-stack).
+Documentation uses the [Diátaxis](https://diataxis.fr) framework
+and the [Sphinx Stack](https://github.com/canonical/sphinx-stack).
+All documentation must follow the [Starcraft style
+guide](https://documentation.ubuntu.com/starflow/latest/how-to/starcraft-style-guide/)
+and the overall [Canonical style guide](https://documentation.ubuntu.com/style-guide/).
 
 ```bash
 make setup-docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ and test infrastructure.
 This repository is an upstream repository for more than 20 Starcraft projects, such as
 Snapcraft, Rockcraft, craft-application, and craft-parts.
 
-The source code for these projects is at https://github.com/canonical/<project>.
+The source code for these projects is at
+https://github.com/canonical/<project-name-in-lowercase>.
 
 Repos that use starbase track it as a git remote named `starbase` and periodically merge
 changes from `starbase/main`.
@@ -61,6 +62,9 @@ make lint-docs
 - Never speculate about code you haven't inspected.
 - Follow the project's existing conventions regarding style, docstrings, logging, and
   comments.
+- Comments should explain complex business logic, non-obvious algorithms, regex, and
+  other "gotchas". Comments should brief, explain "why" not "how", and be helpful for
+  future maintainers.
 - Update relevant documentation and release notes to reflect code changes.
 
 ## Processes


### PR DESCRIPTION
Adds an:
- Agents template for craft apps
- Agents template for craft libraries
- Agents file for starbase itself

Sources used:
- Evaluating AGENTS.md: Are Repository-Level Context Files Helpful for Coding Agents? ([source](https://arxiv.org/abs/2602.11988))
- On the Impact of AGENTS.md Files on the Efficiency of AI Coding Agents ([source](https://arxiv.org/abs/2601.20404))
- Prompting best practices from the Claude API docs ([source](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices))
- https://agents.md/
  - This is the official standard for agents files. It covers the file name, loosely covers file discovery, and doesn't really cover file contents.

(CRAFT-5188)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
