### PR TITLE
docs: resolve `docs-lint` issues

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -322,7 +322,7 @@ ifneq ($(CI),)
 	@echo ::group::$@
 endif
 	uv run $(UV_DOCS_GROUPS) sphinx-lint docs \
-	--ignore docs/.sphinx \
+	--ignore docs/_dev \
 	--ignore docs/_build \
 	--ignore docs/reference/commands \
 	--enable all \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -202,6 +202,9 @@ linkcheck_ignore = [
 # Give linkcheck multiple tries on failure
 linkcheck_retries = 20
 
+# Report timeouts as 'timeout' instead of 'broken'
+linkcheck_report_timeouts_as_broken = False
+
 
 ########################
 # Configuration extras #


### PR DESCRIPTION
* Ignore the `docs/_dev/` directory when running the Sphinx linter
* Configure the link checker to use the more modern timeout reporting

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [X] I've successfully run `make lint && make test`.
~~I've added or updated any relevant documentation.~~
~~In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.~~
- [ ] I've updated the relevant release notes.
