### PR TITLE
ci: set read permissions for qa workflow

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -9,6 +9,10 @@ on:
       - "renovate/*"
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   filter:
     runs-on: ubuntu-slim


### PR DESCRIPTION
External projects don't need this, but internal projects do. They can't run actions like paths-filter that rely on the GitHub API without these explicit permissions.

Our craft actions aren't affected by this because they don't use the API.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
