### PR TITLE
docs: fix AGENTS.md typo

### DIFF
--- a/AGENTS.app.md
+++ b/AGENTS.app.md
@@ -112,7 +112,7 @@ make lint-docs
 - Follow the project's existing conventions regarding style, docstrings, logging,
   comments, and testing.
 - Comments should explain complex business logic, non-obvious algorithms, regex, and
-  other "gotchas". Comments should brief, explain "why" not "how", and be helpful for
+  other "gotchas". Comments should be brief, explain "why" not "how", and be helpful for
   future maintainers.
 - Update relevant documentation and release notes to reflect code changes.
 

--- a/AGENTS.lib.md
+++ b/AGENTS.lib.md
@@ -107,7 +107,7 @@ make lint-docs
 - Follow the project's existing conventions regarding style, docstrings, logging,
   comments, and testing.
 - Comments should explain complex business logic, non-obvious algorithms, regex, and
-  other "gotchas". Comments should brief, explain "why" not "how", and be helpful for
+  other "gotchas". Comments should be brief, explain "why" not "how", and be helpful for
   future maintainers.
 - Update relevant documentation and release notes to reflect code changes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ make lint-docs
 - Follow the project's existing conventions regarding style, docstrings, logging, and
   comments.
 - Comments should explain complex business logic, non-obvious algorithms, regex, and
-  other "gotchas". Comments should brief, explain "why" not "how", and be helpful for
+  other "gotchas". Comments should be brief, explain "why" not "how", and be helpful for
   future maintainers.
 - Update relevant documentation and release notes to reflect code changes.
 


### PR DESCRIPTION
Just some good ol' typo fixes.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
