### PR TITLE
test: add version test module

### DIFF
--- a/tests/unit/starbase/test_init.py
+++ b/tests/unit/starbase/test_init.py
@@ -22,10 +22,6 @@ import starcraft
 from pytest_mock import MockerFixture
 
 
-def test_version():
-    assert starcraft.__version__ is not None
-
-
 def test_hello(mocker: MockerFixture):
     mock_print = mocker.patch("builtins.print")
 

--- a/tests/unit/starbase/test_version.py
+++ b/tests/unit/starbase/test_version.py
@@ -23,7 +23,7 @@ import starcraft
 
 @pytest.fixture
 def get_major_minor_version():
-    """Fixture method that duplicates version trimming in docs/conf.py."""
+    """Fixture function that duplicates version trimming in docs/conf.py."""
 
     def _trim(version):
         expression = re.compile(r"\d+\.\d+")

--- a/tests/unit/starbase/test_version.py
+++ b/tests/unit/starbase/test_version.py
@@ -40,7 +40,7 @@ def test_version():
 
 
 @pytest.mark.parametrize(
-    "version,major_minor",  # NOQA: PT006
+    ("version", "major_minor"),
     [
         ("9.0.0", "9.0"),  # Tagged
         ("9.0.0-23-gc2a9d6349", "9.0"),  # Tagged + new commits

--- a/tests/unit/starbase/test_version.py
+++ b/tests/unit/starbase/test_version.py
@@ -25,10 +25,11 @@ import starcraft
 def get_major_minor_version():
     """Fixture function that duplicates version trimming in docs/conf.py."""
 
-    def _trim(version):
-        expression = re.compile(r"\d+\.\d+")
+    def _trim(version: str) -> str:
+        match = re.match(r"\d+\.\d+", version)
+        assert match is not None
 
-        return expression.match(version).group()
+        return match.group()
 
     return _trim
 
@@ -46,6 +47,6 @@ def test_version():
         ("0.0.post836+g494e37055.d20260612", "0.0"),  # Untagged
     ],
 )
-def test_version_tagged(version, major_minor, get_major_minor_version):
+def test_version_major_minor(version, major_minor, get_major_minor_version):
     """Test the version-to-major-minor function."""
     assert get_major_minor_version(version) == major_minor

--- a/tests/unit/starbase/test_version.py
+++ b/tests/unit/starbase/test_version.py
@@ -1,0 +1,51 @@
+# This file is part of starcraft.
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Basic tests for Starbase version attributes."""
+
+import re
+
+import pytest
+import starcraft
+
+
+@pytest.fixture
+def get_major_minor_version():
+    """Fixture method that duplicates version trimming in docs/conf.py."""
+
+    def _trim(version):
+        expression = re.compile(r"\d+\.\d+")
+
+        return expression.match(version).group()
+
+    return _trim
+
+
+def test_version():
+    """Test that the version attribute is generating."""
+    assert starcraft.__version__ is not None
+
+
+@pytest.mark.parametrize(
+    "version,major_minor",  # NOQA: PT006
+    [
+        ("9.0.0", "9.0"),  # Tagged
+        ("9.0.0-23-gc2a9d6349", "9.0"),  # Tagged + new commits
+        ("0.0.post836+g494e37055.d20260612", "0.0"),  # Untagged
+    ],
+)
+def test_version_tagged(version, major_minor, get_major_minor_version):
+    """Test the version-to-major-minor function."""
+    assert get_major_minor_version(version) == major_minor


### PR DESCRIPTION
The version attribute inside a craft (`craft.__version__`) is generated by Setuptools, so it's outside of the scope of the modules. The docs, however, rely on it for the version in the toolbar.

This PR adds a standalone test module for the version string, and checks against common values. It mocks a function that I plan to add to `conf.py`, but isn't implemented yet.

This is a first step toward fixing #532.

## Concerns

There's nothing to guarantee `conf.py` will have this function. We're creating a value in the docs, then mocking the logic in an unrelated test, so there's no coupling.

I think it would be more ideal if each craft could provide something like `craft.__version_major_minor__`, so the logic would reside in the app itself, not the docs. Is there a simple place to put that?


---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
