### PR TITLE
ci: add ubuntu-26.04 test platforms to QA workflow

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -37,3 +37,5 @@ jobs:
     needs: filter
     with:
       source-files: ${{ needs.filter.outputs.source-files }}
+      fast-test-platforms: '["jammy", "noble", "ubuntu-26.04", "ubuntu-26.04-arm"]'
+      slow-test-platforms: '["jammy", "ubuntu-26.04", "ubuntu-26.04-arm"]'


### PR DESCRIPTION
This PR adds `ubuntu-26.04` and `ubuntu-26.04-arm` to the list of test platforms for both fast and slow tests in the `QA` workflow.