### PR TITLE
build(docs): override docs-clean target

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -8,6 +8,8 @@ SOURCES=$(wildcard *.py) $(PROJECT) tests
 export DOCS_BUILDDIR ?= _build
 export DOCS_VENVDIR ?= ../.venv
 export VALE_DIR ?= $(DOCS_VENVDIR)/lib/python*/site-packages/vale
+export DEV_DIR ?= docs/_dev
+export VALE_CONFIG ?= $(DEV_DIR)/vale.ini
 export SPHINX_AUTOBUILD_OPTS ?= --ignore "$(DOCS_VENVDIR)/*" --ignore "reference/commands/*" -D=llms_txt_enabled=0
 
 ifneq ($(OS),Windows_NT)
@@ -296,8 +298,10 @@ docs-setup: setup-docs
 # we pass a null dir instead.
 .PHONY: docs-clean
 docs-clean:  ##- Clean the temporary files used in documentation
-	VENVDIR=$(mktemp)
-	$(MAKE) -C docs clean --no-print-directory
+	$(MAKE) -C docs clean-doc --no-print-directory
+	rm -rf $(DEV_DIR)/node_modules/
+	rm -rf $(DEV_DIR)/styles
+	rm -rf $(VALE_CONFIG)
 
 # Override for `help` target in docs project
 .PHONY: docs-help

--- a/common.mk
+++ b/common.mk
@@ -7,9 +7,7 @@ SOURCES=$(wildcard *.py) $(PROJECT) tests
 # docs Makefile.
 export DOCS_BUILDDIR ?= _build
 export DOCS_VENVDIR ?= ../.venv
-export DEV_DIR ?= docs/_dev
 export VALE_DIR ?= $(DOCS_VENVDIR)/lib/python*/site-packages/vale
-export VALE_CONFIG ?= $(DEV_DIR)/vale.ini
 export SPHINX_AUTOBUILD_OPTS ?= --ignore "$(DOCS_VENVDIR)/*" --ignore "reference/commands/*" -D=llms_txt_enabled=0
 
 ifneq ($(OS),Windows_NT)
@@ -299,9 +297,9 @@ docs-setup: setup-docs
 .PHONY: docs-clean
 docs-clean:  ##- Clean the temporary files used in documentation
 	$(MAKE) -C docs clean-doc --no-print-directory
-	rm -rf $(DEV_DIR)/node_modules/
-	rm -rf $(DEV_DIR)/styles
-	rm -rf $(VALE_CONFIG)
+	rm -rf docs/_dev/node_modules/
+	rm -rf docs/_dev/styles
+	rm -rf docs/_dev/vale.ini
 
 # Override for `help` target in docs project
 .PHONY: docs-help

--- a/common.mk
+++ b/common.mk
@@ -7,8 +7,8 @@ SOURCES=$(wildcard *.py) $(PROJECT) tests
 # docs Makefile.
 export DOCS_BUILDDIR ?= _build
 export DOCS_VENVDIR ?= ../.venv
-export VALE_DIR ?= $(DOCS_VENVDIR)/lib/python*/site-packages/vale
 export DEV_DIR ?= docs/_dev
+export VALE_DIR ?= $(DOCS_VENVDIR)/lib/python*/site-packages/vale
 export VALE_CONFIG ?= $(DEV_DIR)/vale.ini
 export SPHINX_AUTOBUILD_OPTS ?= --ignore "$(DOCS_VENVDIR)/*" --ignore "reference/commands/*" -D=llms_txt_enabled=0
 

--- a/common.mk
+++ b/common.mk
@@ -292,8 +292,7 @@ endif
 .PHONY: docs-setup
 docs-setup: setup-docs
 
-# Override for `clean` target in docs project. We don't want to touch `.venv`, so
-# we pass a null dir instead.
+# Override for `clean` target in docs project. We don't want to touch `.venv`.
 .PHONY: docs-clean
 docs-clean:  ##- Clean the temporary files used in documentation
 	$(MAKE) -C docs clean-doc --no-print-directory

--- a/common.mk
+++ b/common.mk
@@ -299,7 +299,7 @@ docs-clean:  ##- Clean the temporary files used in documentation
 	$(MAKE) -C docs clean-doc --no-print-directory
 	rm -rf docs/_dev/node_modules/
 	rm -rf docs/_dev/styles
-	rm -rf docs/_dev/vale.ini
+	rm -f docs/_dev/vale.ini
 
 # Override for `help` target in docs project
 .PHONY: docs-help


### PR DESCRIPTION
When we run `make docs-clean`, it deletes the venv, which isn't great. However, simply updating `VENVDIR` to `DOCS_VENVDIR` takes us back to an old issue, where `rm` doesn't delete anything:

```
DOCS_VENVDIR=
make -C docs clean --no-print-directory
git clean -fx "_build"
rm -rf _dev/.doctrees
rm -rf 
rm -rf _dev/node_modules/
rm -rf _dev/styles
rm -rf _dev/vale.ini
```

The `docs-clean` target in the docs Makefile has an ambiguous `test` command that fails if we export a temp directory to it. To work around that, this PR overrides the target completely, so we don't require a temp dir to delete in the first place.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
