### PR TITLE
ci: install uv in renovate check workflow

### DIFF
--- a/.github/workflows/check-renovate.yaml
+++ b/.github/workflows/check-renovate.yaml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - name: Install renovate
         run: npm install --global re2 renovate
       - name: Enable ssh access


### PR DESCRIPTION
Installs `uv` in the Renovate check workflow to support validating/updating `uv.lock` files.