### PR TITLE
ci: do not double-lint renovate PRs

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -6,7 +6,6 @@ on:
       - "feature/*"
       - "hotfix/*"
       - "release/*"
-      - "renovate/*"
   pull_request:
 
 permissions:


### PR DESCRIPTION
The combination of `renovate/*` and `pull_request:` as triggers meant that Renovate PRs would trigger the lint workflow twice.

The main (hypothetical) benefit here would be that Renovate would potentially not create bumping PRs if there were linting errors, but we'd often not want that behavior (e.g., Ruff updates) and it didn't seem to actually do this anyways??

As it stands, it just causes me to have to rerun two workflows instead of only one workflow when there's a flaky failure in our link checker on a Renovate PR.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
