### PR TITLE
docs: declare slug in config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,9 +109,7 @@ html_theme_options = {
   "source_edit_link": "https://github.com/canonical/starbase",
 }
 
-# TODO: If your documentation is hosted on https://documentation.ubuntu.com/,
-#       uncomment and set to the RTD slug.
-# slug = ""
+slug = "craft-parts"
 
 
 #########################

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,7 +109,7 @@ html_theme_options = {
   "source_edit_link": "https://github.com/canonical/starbase",
 }
 
-# The version slug passed to the sphinx-notfound-page extension
+# The project slug passed to the sphinx-notfound-page extension
 # TODO: Set this to the project's RTD slug
 slug = "starbase"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,7 +109,7 @@ html_theme_options = {
   "source_edit_link": "https://github.com/canonical/starbase",
 }
 
-# The version slug passed to the sphinx-notfound-page extenssion
+# The version slug passed to the sphinx-notfound-page extension
 # TODO: Set this to the project's RTD slug
 slug = "starbase"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,7 +109,9 @@ html_theme_options = {
   "source_edit_link": "https://github.com/canonical/starbase",
 }
 
-slug = "craft-parts"
+# The version slug passed to the sphinx-notfound-page extenssion
+# TODO: Set this to the project's RTD slug
+slug = "starbase"
 
 
 #########################


### PR DESCRIPTION
Canonical Sphinx uses this to configure the sphinx-notfound-page extension.

Live 404 page: https://documentation.ubuntu.com/starbase/oops

PR build 404 page: https://canonical-ubuntu-documentation-library--583.com.readthedocs.build/starbase/583/oops

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
