### PR TITLE
fix(ci): resolve all zizmor findings in GitHub workflows

### DIFF
--- a/.github/workflows/check-renovate.yaml
+++ b/.github/workflows/check-renovate.yaml
@@ -17,19 +17,24 @@ on:
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       - name: Install uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Install renovate
+        # zizmor: ignore[adhoc-packages] renovate is installed ad-hoc here to validate its own config; there is no lockfile for this ephemeral tool.
         run: npm install --global re2 renovate
       - name: Enable ssh access
-        uses: mxschmitt/action-tmate@v3
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3.24
         if: ${{ inputs.enable_ssh_access }}
         with:
           limit-access-to-actor: true

--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -12,10 +12,12 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: canonical/starflow/.github/workflows/policy.yaml@main
+    uses: canonical/starflow/.github/workflows/policy.yaml@main # zizmor: ignore[unpinned-uses] starflow workflows are exempt from hash-pinning
   python-scans:
     name: Security scan
-    uses: canonical/starflow/.github/workflows/scan-python.yaml@main
+    permissions:
+      contents: read
+    uses: canonical/starflow/.github/workflows/scan-python.yaml@main # zizmor: ignore[unpinned-uses] starflow workflows are exempt from hash-pinning
     with:
       osv-extra-args: "--config=osv-scanner.toml"
       osv-exclude-paths: |

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -19,9 +19,10 @@ jobs:
       source-files: ${{ steps.filter.outputs.source-files }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
@@ -31,12 +32,12 @@ jobs:
             source-files:
               - '!({docs/**,*.md,**/*.md,.readthedocs.yaml})'
   lint:
-    uses: canonical/starflow/.github/workflows/lint-python.yaml@main
+    uses: canonical/starflow/.github/workflows/lint-python.yaml@main # zizmor: ignore[unpinned-uses] starflow workflows are exempt from hash-pinning
     needs: filter
     with:
       source-files: ${{ needs.filter.outputs.source-files }}
   test:
-    uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    uses: canonical/starflow/.github/workflows/test-python.yaml@main # zizmor: ignore[unpinned-uses] starflow workflows are exempt from hash-pinning
     needs: filter
     with:
       source-files: ${{ needs.filter.outputs.source-files }}

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -6,19 +6,20 @@ on:
       # https://github.com/canonical/starbase/settings/tag_protection
       - "[0-9]+.[0-9]+.[0-9]+"
 
-permissions:
-  contents: write
-
 jobs:
   source-wheel:
     runs-on: [self-hosted]
+    permissions:
+      contents: read
     steps:
       - name: Install uv
         run: |
           sudo snap install --classic astral-uv
           sudo apt --yes install python3-venv
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Fetch tag annotations
         run: |
           # Note: we fetch the tags here instead of using actions/checkout's "fetch-tags"
@@ -32,7 +33,7 @@ jobs:
           uv run -m build
           uv run twine check dist/*
       - name: Upload pypi packages artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pypi-packages
           path: dist/
@@ -44,7 +45,7 @@ jobs:
       id-token: write
     steps:
       - name: Get packages
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pypi-packages
           path: dist/
@@ -52,21 +53,23 @@ jobs:
         # Note: this action uses PyPI's support for Trusted Publishers
         # It needs a configuration on the PyPI project - see:
         # https://docs.pypi.org/trusted-publishers/adding-a-publisher/#github-actions
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
   github-release:
     needs: ["source-wheel"]
     runs-on: [self-hosted]
+    permissions:
+      contents: write
     steps:
       - name: Get pypi artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pypi-packages
       - name: Release
-        uses: softprops/action-gh-release@v3
-        with:
-          # Generate release notes on the new GH release
-          generate_release_notes: true
-          # Add wheel and source tarball
-          files: |
-            *.whl
-            *.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        # Use the gh CLI directly instead of a third-party action, since the
+        # runner already provides it and it covers our needs. The tag name is
+        # passed via an environment variable rather than interpolated
+        # directly into the script to avoid shell/template injection.
+        run: gh release create "$RELEASE_TAG" --generate-notes -- *.whl *.tar.gz

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -68,8 +68,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.ref_name }}
-        # Use the gh CLI directly instead of a third-party action, since the
-        # runner already provides it and it covers our needs. The tag name is
-        # passed via an environment variable rather than interpolated
-        # directly into the script to avoid shell/template injection.
         run: gh release create "$RELEASE_TAG" --generate-notes -- *.whl *.tar.gz

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -8,8 +8,11 @@ on:
 
 jobs:
   TICS:
-    uses: canonical/starflow/.github/workflows/tics.yaml@main
+    permissions:
+      contents: read
+    uses: canonical/starflow/.github/workflows/tics.yaml@main # zizmor: ignore[unpinned-uses] starflow workflows are exempt from hash-pinning
     # Uncomment this and add your project's name on Tiobe TICS
     # with:
     #   project: "starcraft"
-    secrets: inherit
+    secrets:
+      TICSAUTHTOKEN: ${{ secrets.TICSAUTHTOKEN }}


### PR DESCRIPTION
> 🤖 This PR description was generated by an AI agent (GitHub Copilot CLI).

## Summary

Fixes every finding reported by [zizmor](https://docs.zizmor.sh) across all GitHub Actions workflows (44 findings → 0).

## Changes

- Pin all third-party actions to commit hashes (`unpinned-uses`), except `canonical/starflow/...@main` references, which are intentionally kept at `@main` per team policy and suppressed with a documented `zizmor: ignore` comment.
- Add `persist-credentials: false` to all `actions/checkout` steps (`artipacked`).
- Scope down permissions (`excessive-permissions`): replace workflow-level `contents: write` in `release-publish.yaml` with per-job permissions, and add explicit `permissions:` blocks where missing.
- Replace `secrets: inherit` in `tics.yaml` with an explicit pass-through of just the one secret needed (`secrets-inherit`).
- Replace `softprops/action-gh-release` with a `gh release create` script step (`superfluous-actions`), passing the tag via an env var to avoid `template-injection`.
- Add a documented, justified ignore for the ad-hoc renovate npm install (`adhoc-packages`) since it has no meaningful lockfile.

## Testing

- `zizmor .` → 0 findings
- `make lint-actions` / `make lint-prettier` → pass
- All CI checks pass, including the repo's own zizmor audit job