### PR TITLE
docs: fix version in title

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,14 +27,10 @@ project = "Starbase"
 # Author name; used in the default copyright statement in the page footer
 author = "Canonical Ltd."
 
-# Format the product name and version for the TOC and HTML title
-# TODO: When the product begins versioning, uncomment this block.
-# release = <starcraft>.__version__
-# if ".post" in release:
-#     release = "dev"
-# else:
-#     major, minor, *_ = release.split(".")
-#     release = f"{major}.{minor}"
+# Version string in sidebar
+# TODO: Uncomment and replace 'starcraft' with the product's main module on release
+# major, minor, *_ = starcraft.__version__.split(".")
+# release = "dev" if os.environ.get("READTHEDOCS_VERSION") == "latest" else f"{major}.{minor}"
 
 # The year in the copyright statement
 copyright = f"2023-{datetime.date.today().year}"


### PR DESCRIPTION
With this change, all local, PR, and branch builds will show the major and minor version in the docs title. The only exception is the 'latest' branch build, which will show 'dev' as the version.

This change was brought about by the simplification of our RTD version slugs.

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
