### PR TITLE
docs: remove `html_title` from config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,10 +35,6 @@ author = "Canonical Ltd."
 # The year in the copyright statement
 copyright = f"2023-{datetime.date.today().year}"
 
-# Sidebar documentation title
-# To disable the title, set it to an empty string.
-html_title = project + " documentation"
-
 # Documentation website URL
 ogp_site_url = "https://canonical-starbase.readthedocs-hosted.com/"
 


### PR DESCRIPTION
When this is set, it overrides the title that gets composed by default (which is <project> <release> documentation).

https://github.com/pradyunsg/furo/blob/522d7e6534706a5acc916dee5ab35a3102e937e8/src/furo/theme/furo/sidebar/brand.html#L29

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
