### PR TITLE
ci: add zizmor actions permission

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   policy:
     permissions:
+      actions: read
       contents: read
       security-events: write
     uses: canonical/starflow/.github/workflows/policy.yaml@main # zizmor: ignore[unpinned-uses] starflow workflows are exempt from hash-pinning


### PR DESCRIPTION
Updates permissions for zizmor.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
