### PR TITLE
build: run docs-clean as part of clean target

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -91,7 +91,7 @@ else
 endif
 
 .PHONY: clean
-clean:  ## Clean up the development environment
+clean: docs-clean  ## Clean up the development environment
 	uv tool run pyclean .
 	rm -rf dist build docs/_build docs/_linkcheck docs/reference/gen *.snap .coverage* .venv
 


### PR DESCRIPTION
Other top-level targets, like `make lint`, target the docs. `make clean` should follow the same pattern.

I was having an issue where `make lint-docs` was only failing in CI. The problem was that `docs/_dev/styles/` was out-of-date and `make clean` wasn't cleaning it.

Source: https://github.com/canonical/snapcraft/pull/6391#discussion_r3807835072

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
