### PR TITLE
chore: make zizmor configuration less verbose

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -12,12 +12,12 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: canonical/starflow/.github/workflows/policy.yaml@main # zizmor: ignore[unpinned-uses] starflow workflows are exempt from hash-pinning
+    uses: canonical/starflow/.github/workflows/policy.yaml@main
   python-scans:
     name: Security scan
     permissions:
       contents: read
-    uses: canonical/starflow/.github/workflows/scan-python.yaml@main # zizmor: ignore[unpinned-uses] starflow workflows are exempt from hash-pinning
+    uses: canonical/starflow/.github/workflows/scan-python.yaml@main
     with:
       osv-extra-args: "--config=osv-scanner.toml"
       osv-exclude-paths: |

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -32,12 +32,12 @@ jobs:
             source-files:
               - '!({docs/**,*.md,**/*.md,.readthedocs.yaml})'
   lint:
-    uses: canonical/starflow/.github/workflows/lint-python.yaml@main # zizmor: ignore[unpinned-uses] starflow workflows are exempt from hash-pinning
+    uses: canonical/starflow/.github/workflows/lint-python.yaml@main
     needs: filter
     with:
       source-files: ${{ needs.filter.outputs.source-files }}
   test:
-    uses: canonical/starflow/.github/workflows/test-python.yaml@main # zizmor: ignore[unpinned-uses] starflow workflows are exempt from hash-pinning
+    uses: canonical/starflow/.github/workflows/test-python.yaml@main
     needs: filter
     with:
       source-files: ${{ needs.filter.outputs.source-files }}

--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -10,7 +10,7 @@ jobs:
   TICS:
     permissions:
       contents: read
-    uses: canonical/starflow/.github/workflows/tics.yaml@main # zizmor: ignore[unpinned-uses] starflow workflows are exempt from hash-pinning
+    uses: canonical/starflow/.github/workflows/tics.yaml@main
     # Uncomment this and add your project's name on Tiobe TICS
     # with:
     #   project: "starcraft"

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies: # Allow unpinned references to starflow.
+        canonical/starflow/*: ref-pin


### PR DESCRIPTION
This configures zizmor just once to allow any starflow workflows without hash pinning.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
