### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -66,6 +66,7 @@ jobs:
           name: pypi-packages
       - name: Release
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: gh release create "$RELEASE_TAG" --generate-notes -- *.whl *.tar.gz


### PR DESCRIPTION
This step was updated in https://github.com/canonical/starbase/pull/585 to satisfy a zizmor warning.

However, it's [failing](https://github.com/canonical/craft-archives/actions/runs/33912721254/job/101152850081) because `gh` needs to know the repo.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
