### PR TITLE
feat: format toml files with tombi

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,3 +36,6 @@ max_line_length = off
 
 [{*.yaml,*.yml}]
 indent_size = 2
+
+[*.toml]
+indent_size = 2

--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,13 @@ UV_TICS_GROUPS := "--group=tics"
 include common.mk
 
 .PHONY: format
-format: format-ruff format-codespell format-prettier format-shfmt format-pre-commit  ## Run all automatic formatters
+format: format-ruff format-codespell format-prettier format-shfmt format-tombi format-pre-commit  ## Run all automatic formatters
 
 .PHONY: lint
 lint: lint-code lint-docs lint-twine lint-uv-lockfile lint-actions  ## Run all linters
 
 .PHONY: lint-code
-lint-code: lint-ruff lint-ty lint-codespell lint-mypy lint-prettier lint-pyright lint-shfmt lint-shellcheck  ## Run code-specific linters
+lint-code: lint-ruff lint-ty lint-codespell lint-mypy lint-prettier lint-pyright lint-shfmt lint-shellcheck lint-tombi  ## Run code-specific linters
 
 .PHONY: pack
 pack: pack-pip  ## Build all packages

--- a/common.mk
+++ b/common.mk
@@ -123,6 +123,10 @@ format-shfmt: install-shfmt ##- Format shell scripts
 	@# so explicitly filter them out
 	git ls-files -z | xargs -0 sh -c 'for f; do case "$$f" in *.sh.j2) continue;; esac; file --mime-type -Nn -- "$$f" | grep -q shellscript && printf "%s\0" "$$f"; done' -- | xargs -0r shfmt -w
 
+.PHONY: format-tombi
+format-tombi: install-tombi  ##- Format TOML files with tombi
+	tombi format
+
 .PHONY: lint-ruff
 lint-ruff: install-ruff  ##- Lint with ruff
 ifneq ($(CI),)
@@ -214,6 +218,16 @@ ifneq ($(CI),)
 	@echo ::group::$@
 endif
 	$(PRETTIER) --check $(PRETTIER_FILES)
+ifneq ($(CI),)
+	@echo ::endgroup::
+endif
+
+.PHONY: lint-tombi
+lint-tombi: install-tombi  ##- Check TOML formatting with tombi
+ifneq ($(CI),)
+	@echo ::group::$@
+endif
+	tombi format --check --diff
 ifneq ($(CI),)
 	@echo ::endgroup::
 endif
@@ -458,6 +472,18 @@ else ifneq ($(shell which brew),)
 	brew install shfmt
 else
 	$(warning shfmt not installed. Please install it yourself.)
+endif
+
+.PHONY: install-tombi
+install-tombi:
+ifneq ($(shell which tombi),)
+else ifneq ($(shell which snap),)
+	sudo snap install --classic tombi
+else ifneq ($(shell which brew),)
+	brew install tombi
+else
+	make install-uv
+	uv tool install tombi
 endif
 
 .PHONY: install-ty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,18 @@
 [project]
 name = "starcraft"
 description = "The basis for Starcraft team packages"
-dynamic = ["version"]
+readme = { file = "README.md", content-type = "text/markdown" }
+requires-python = ">=3.10"
+license = "LGPL-3.0"
+classifiers = [
+  "Development Status :: 1 - Planning",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.12",
+]
 # Applications should avoid CVEs in direct dependencies by setting a minimum version in 'dependencies'.
 dependencies = []
-classifiers = [
-    "Development Status :: 1 - Planning",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.12",
-]
-license = "LGPL-3.0"
-requires-python = ">=3.10"
-readme = { file = "README.md", content-type = "text/markdown" }
+dynamic = ["version"]
 
 [project.scripts]
 starcraft-hello = "starcraft:hello"
@@ -20,153 +20,71 @@ starcraft-hello = "starcraft:hello"
 # Applications should avoid CVEs in optional, direct dependencies by setting a minimum
 # version in 'dependency-groups'.
 [dependency-groups]
-lint = [
-    # Left empty for scaffolding and Makefile compatibility
-]
-types = [
-    "mypy[reports]~=2.3.0",
-    "types-Pygments",
-    "types-colorama",
-    "types-setuptools",
+dev = [
+  "build>=0.7.0",
+  "coverage[toml]~=7.4",
+  "mypy[reports]~=2.3.0",
+  "pytest~=9.0",
+  "pytest-cov~=7.0",
+  "pytest-mock~=3.12",
+  "types-Pygments",
+  "types-colorama",
+  "types-setuptools",
 ]
 docs = [
-    "sphinx-lint~=1.0",
-    "sphinxext-rediraffe==0.3.0",
-    {include-group = "docs-sphinx-stack"},
+  "sphinx-lint~=1.0",
+  "sphinxext-rediraffe==0.3.0",
+  { include-group = "docs-sphinx-stack" },
 ]
 # We disable the unused but default SP dependencies slated for removal
 # https://warthogs.atlassian.net/browse/DOCPR-2387
 docs-sphinx-stack = [
-    "canonical-sphinx~=0.6",
-    "myst-parser~=4.0",
-    "packaging~=26.1",
-    "rst2html>=2020.7.4",
-    "sphinx-autobuild>=2024.10.3",
-    # "sphinx-config-options~=0.1",
-    # "sphinx-contributor-listing~=0.1",
-    "sphinx-design==0.6.1",
-    # "sphinx-filtered-toctree~=0.1",
-    # "sphinx-last-updated-by-git~=0.3",
-    "sphinx-llm~=0.4",
-    "sphinx-notfound-page~=1.1",
-    "sphinx-related-links~=0.1",
-    # "sphinx-reredirects==0.1.6",
-    "sphinx-rerediraffe>=0.0.3,<1.0.0",
-    "sphinx-roles~=0.1",
-    "sphinx-sitemap~=2.9",
-    # "sphinx-tabs~=3.5",
-    "sphinx-terminal~=1.0",
-    # "sphinx-ubuntu-images~=0.1",
-    # "sphinx-youtube-links~=0.1",
-    "sphinxcontrib-jquery~=4.1",
-    # "sphinxcontrib-svg2pdfconverter[cairosvg]~=2.1",
-    "sphinxext-opengraph~=0.13",
-    "vale~=3.13",
+  "canonical-sphinx~=0.6",
+  "myst-parser~=4.0",
+  "packaging~=26.1",
+  "rst2html>=2020.7.4",
+  "sphinx-autobuild>=2024.10.3",
+  # "sphinx-config-options~=0.1",
+  # "sphinx-contributor-listing~=0.1",
+  "sphinx-design==0.6.1",
+  # "sphinx-filtered-toctree~=0.1",
+  # "sphinx-last-updated-by-git~=0.3",
+  "sphinx-llm~=0.4",
+  "sphinx-notfound-page~=1.1",
+  "sphinx-related-links~=0.1",
+  # "sphinx-reredirects==0.1.6",
+  "sphinx-rerediraffe>=0.0.3,<1.0.0",
+  "sphinx-roles~=0.1",
+  "sphinx-sitemap~=2.9",
+  # "sphinx-tabs~=3.5",
+  "sphinx-terminal~=1.0",
+  # "sphinx-ubuntu-images~=0.1",
+  # "sphinx-youtube-links~=0.1",
+  "sphinxcontrib-jquery~=4.1",
+  # "sphinxcontrib-svg2pdfconverter[cairosvg]~=2.1",
+  "sphinxext-opengraph~=0.13",
+  "vale~=3.13",
 ]
-dev = [
-    "build>=0.7.0",
-    "coverage[toml]~=7.4",
-    "pytest~=9.0",
-    "pytest-cov~=7.0",
-    "pytest-mock~=3.12",
-    "mypy[reports]~=2.3.0",
-    "types-Pygments",
-    "types-colorama",
-    "types-setuptools",
+lint = [
+  # Left empty for scaffolding and Makefile compatibility
 ]
 tics = ["flake8", "pylint"]
-
-[tool.uv]
-constraint-dependencies = [
-    # Basic constraints to allow --resolution=lowest.
-    #
-    # Libraries should avoid CVEs in direct and transitive dependencies by setting a
-    # minimum version in this section.
-    # This allows standalone builds to avoid CVEs while not placing undue constraints on
-    # downstream users of the library.
-    #
-    # Applications should avoid CVEs in transitive dependencies by setting a minimum
-    # version in this section.
-    "cffi>=1.15",
-    "iniconfig>=1.1.0",
-    "httplib2>=0.20.0",
-    "libnacl>=2.0",
-    "lxml>=5.0",
-    "markdown>=3.0",
-    "markupsafe>=2.0",
-    "oauthlib>=3.0.0",
-    "protobuf>=5.0",
-    "pynacl>=1.5",
-    "pyparsing>=3.0.0",
-    "pyproject-hooks>=1.0.0",
-    "pytz>=2020",
-    "pyyaml>=5.0",
-    "regex>=2021.11.10",
-    "setuptools>=50",
-    "sphinx-basic-ng>=1.0.0b1",
-    "starlette>=1.0.1",
-    "tornado>=4.0",
-    "urllib3>=2.0",
-    "webencodings>=0.4.0",
-    "wheel>=0.38",
+types = [
+  "mypy[reports]~=2.3.0",
+  "types-Pygments",
+  "types-colorama",
+  "types-setuptools",
 ]
-
 
 [build-system]
 requires = ["setuptools>=69.0", "setuptools_scm[toml]>=7.1"]
 build-backend = "setuptools.build_meta"
-
-
-[tool.setuptools_scm]
-write_to = "starcraft/_version.py"
-# the version comes from the latest annotated git tag formatted as 'X.Y.Z'
-# version scheme:
-#   - X.Y.Z.post<commits since tag>+g<hash>.d<%Y%m%d>
-# parts of scheme:
-#   - X.Y.Z - most recent git tag
-#   - post<commits since tag>+g<hash> - present when current commit is not tagged
-#   - .d<%Y%m%d> - present when working dir is dirty
-# version scheme when no tags exist:
-#   - 0.0.post<total commits>+g<hash>
-version_scheme = "post-release"
-# deviations from the default 'git describe' command:
-# - only match annotated tags
-# - only match tags formatted as 'X.Y.Z'
-git_describe_command = [
-    "git",
-    "describe",
-    "--dirty",
-    "--long",
-    "--match",
-    "[0-9]*.[0-9]*.[0-9]*",
-    "--exclude",
-    "*[^0-9.]*",
-]
-
-[tool.setuptools.packages.find]
-include = ["*craft*"]
-namespaces = false
 
 [tool.codespell]
 ignore-words-list = "buildd,crate,keyserver,comandos,ro,dedent,dedented"
 skip = ".tox,.git,build,.*_cache,__pycache__,*.tar,*.snap,*.png,./node_modules,./docs/_build,.direnv,.venv,venv,.vscode"
 quiet-level = 3
 check-filenames = true
-
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-line_length = 88
-
-[tool.pytest.ini_options]
-minversion = "7.0"
-testpaths = "tests"
-xfail_strict = true
-addopts = "--ignore=tests/spread"
-markers = ["slow: slow tests"]
 
 [tool.coverage.run]
 branch = true
@@ -176,16 +94,13 @@ omit = ["tests/**"]
 skip_empty = true
 exclude_also = ["if (typing\\.)?TYPE_CHECKING:"]
 
-[tool.pyright]
-strict = ["starcraft"]
-pythonVersion = "3.10"
-pythonPlatform = "Linux"
-exclude = [
-    "**/.*",
-    "**/__pycache__",
-    # pyright might not like the annotations generated by setuptools_scm
-    "**/_version.py",
-]
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 88
 
 [tool.mypy]
 python_version = "3.10"
@@ -208,6 +123,24 @@ no_implicit_optional = true
 module = ["tests.*"]
 strict = false
 
+[tool.pyright]
+strict = ["starcraft"]
+pythonVersion = "3.10"
+pythonPlatform = "Linux"
+exclude = [
+  "**/.*",
+  "**/__pycache__",
+  # pyright might not like the annotations generated by setuptools_scm
+  "**/_version.py",
+]
+
+[tool.pytest.ini_options]
+addopts = "--ignore=tests/spread"
+markers = ["slow: slow tests"]
+minversion = "7.0"
+testpaths = "tests"
+xfail_strict = true
+
 [tool.ruff]
 line-length = 88
 target-version = "py310"
@@ -222,106 +155,106 @@ quote-style = "double"
 [tool.ruff.lint]
 # Follow ST063 - Maintaining and updating linting specifications for updating these.
 # Handy link: https://docs.astral.sh/ruff/rules/
-select = [ # Base linting rule selections.
-    # See the internal document for discussion:
-    # https://docs.google.com/document/d/1i1n8pDmFmWi4wTDpk-JfnWCVUThPJiggyPi2DYwBBu4/edit
-    # All sections here are stable in ruff and shouldn't randomly introduce
-    # failures with ruff updates.
-    "F",     # The rules built into Flake8
-    "E",
-    "W",     # pycodestyle errors and warnings
-    "I",     # isort checking
-    "N",     # PEP8 naming
-    "D",     # Implement pydocstyle checking as well.
-    "UP",    # Pyupgrade - note that some of are excluded below due to Python versions
-    "YTT",   # flake8-2020: Misuse of `sys.version` and `sys.version_info`
-    "ANN",   # Type annotations.
-    "ASYNC", # Catching blocking calls in async functions
-    # flake8-bandit: security testing. https://docs.astral.sh/ruff/rules/#flake8-bandit-s
-    # https://bandit.readthedocs.io/en/latest/plugins/index.html#complete-test-plugin-listing
-    "S101",
-    "S102", # assert or exec
-    "S103",
-    "S108", # File permissions and tempfiles - use #noqa to silence when appropriate.
-    "S104", # Network binds
-    "S105",
-    "S106",
-    "S107", # Hardcoded passwords
-    "S110", # try-except-pass (use contextlib.suppress instead)
-    "S113", # Requests calls without timeouts
-    "S3",   # Serialising, deserialising, hashing, crypto, etc.
-    "S5",   # Unsafe cryptography or YAML loading.
-    "S602", # Subprocess call with shell=true
-    "S701", # jinja2 templates without autoescape
-    "BLE",  # Do not catch blind exceptions
-    "FBT",  # Disallow boolean positional arguments (make them keyword-only)
-    "B0",   # Common mistakes and typos.
-    "A",    # Shadowing built-ins.
-    "COM",  # Trailing commas
-    "C4",   # Encourage comprehensions, which tend to be faster than alternatives.
-    "T10",  # Don't call the debugger in production code
-    "ISC",  # Implicit string concatenation that can cause subtle issues
-    "ICN",  # Only use common conventions for import aliases.
-    "INP",  # Implicit namespace packages
-    # flake8-pie: miscellaneous linters (enabled individually because they're not really related)
-    "PIE790", # Unnecessary pass statement
-    "PIE794", # Multiple definitions of class field
-    "PIE796", # Duplicate value in an enum (reasonable to noqa for backwards compatibility)
-    "PIE804", # Don't use a dict with unnecessary kwargs
-    "PIE807", # prefer `list` over `lambda: []`
-    "PIE810", # Use a tuple rather than multiple calls. E.g. `mystr.startswith(("Hi", "Hello"))`
-    "PYI",    # Linting for type stubs.
-    "PT",     # Pytest
-    "Q",      # Consistent quotations
-    "RSE",    # Errors on pytest raises.
-    "RET",    # Simpler logic after return, raise, continue or break
-    "SLF",    # Prevent accessing private class members.
-    "SIM",    # Code simplification
-    "TID",    # Tidy imports
-    "TC001",  # Checks for first-party imports that are only used for type annotations
-    "TC002",  # Checks for third-party imports that are only used for type annotations
-    "TC003",  # Checks for standard library imports that are only used for type annotations
-    "TC004",  # Remove imports from type-checking guard blocks if used at runtime
-    "TC005",  # Delete empty type-checking blocks
-    "ARG",    # Unused arguments
-    "PTH",    # Migrate to pathlib
-    "FIX",    # All TODOs, FIXMEs, etc. should be turned into issues instead.
-    "ERA",    # Don't check in commented out code
-    "PGH",    # Pygrep hooks
-    "PL",     # Pylint
-    "TRY",    # Cleaner try/except,
-    "FLY",    # Detect things that would be better as f-strings.
-    "PERF",   # Catch things that can slow down the application like unnecessary casts to list.
-    "RUF001",
-    "RUF002",
-    "RUF003", # Ambiguous unicode characters
-    "RUF005", # Encourages unpacking rather than concatenation
-    "RUF008", # Do not use mutable default values for dataclass attributes
-    "B035",   # Don't use static keys in dict comprehensions.
-    "RUF013", # Prohibit implicit Optionals (PEP 484)
-    "RUF100", # #noqa directive that doesn't flag anything
-    "RUF200", # If ruff fails to parse pyproject.toml...
+select = [  # Base linting rule selections.
+  # See the internal document for discussion:
+  # https://docs.google.com/document/d/1i1n8pDmFmWi4wTDpk-JfnWCVUThPJiggyPi2DYwBBu4/edit
+  # All sections here are stable in ruff and shouldn't randomly introduce
+  # failures with ruff updates.
+  "F",  # The rules built into Flake8
+  "E",
+  "W",  # pycodestyle errors and warnings
+  "I",  # isort checking
+  "N",  # PEP8 naming
+  "D",  # Implement pydocstyle checking as well.
+  "UP",  # Pyupgrade - note that some of are excluded below due to Python versions
+  "YTT",  # flake8-2020: Misuse of `sys.version` and `sys.version_info`
+  "ANN",  # Type annotations.
+  "ASYNC",  # Catching blocking calls in async functions
+  # flake8-bandit: security testing. https://docs.astral.sh/ruff/rules/#flake8-bandit-s
+  # https://bandit.readthedocs.io/en/latest/plugins/index.html#complete-test-plugin-listing
+  "S101",
+  "S102",  # assert or exec
+  "S103",
+  "S108",  # File permissions and tempfiles - use #noqa to silence when appropriate.
+  "S104",  # Network binds
+  "S105",
+  "S106",
+  "S107",  # Hardcoded passwords
+  "S110",  # try-except-pass (use contextlib.suppress instead)
+  "S113",  # Requests calls without timeouts
+  "S3",  # Serialising, deserialising, hashing, crypto, etc.
+  "S5",  # Unsafe cryptography or YAML loading.
+  "S602",  # Subprocess call with shell=true
+  "S701",  # jinja2 templates without autoescape
+  "BLE",  # Do not catch blind exceptions
+  "FBT",  # Disallow boolean positional arguments (make them keyword-only)
+  "B0",  # Common mistakes and typos.
+  "A",  # Shadowing built-ins.
+  "COM",  # Trailing commas
+  "C4",  # Encourage comprehensions, which tend to be faster than alternatives.
+  "T10",  # Don't call the debugger in production code
+  "ISC",  # Implicit string concatenation that can cause subtle issues
+  "ICN",  # Only use common conventions for import aliases.
+  "INP",  # Implicit namespace packages
+  # flake8-pie: miscellaneous linters (enabled individually because they're not really related)
+  "PIE790",  # Unnecessary pass statement
+  "PIE794",  # Multiple definitions of class field
+  "PIE796",  # Duplicate value in an enum (reasonable to noqa for backwards compatibility)
+  "PIE804",  # Don't use a dict with unnecessary kwargs
+  "PIE807",  # prefer `list` over `lambda: []`
+  "PIE810",  # Use a tuple rather than multiple calls. E.g. `mystr.startswith(("Hi", "Hello"))`
+  "PYI",  # Linting for type stubs.
+  "PT",  # Pytest
+  "Q",  # Consistent quotations
+  "RSE",  # Errors on pytest raises.
+  "RET",  # Simpler logic after return, raise, continue or break
+  "SLF",  # Prevent accessing private class members.
+  "SIM",  # Code simplification
+  "TID",  # Tidy imports
+  "TC001",  # Checks for first-party imports that are only used for type annotations
+  "TC002",  # Checks for third-party imports that are only used for type annotations
+  "TC003",  # Checks for standard library imports that are only used for type annotations
+  "TC004",  # Remove imports from type-checking guard blocks if used at runtime
+  "TC005",  # Delete empty type-checking blocks
+  "ARG",  # Unused arguments
+  "PTH",  # Migrate to pathlib
+  "FIX",  # All TODOs, FIXMEs, etc. should be turned into issues instead.
+  "ERA",  # Don't check in commented out code
+  "PGH",  # Pygrep hooks
+  "PL",  # Pylint
+  "TRY",  # Cleaner try/except,
+  "FLY",  # Detect things that would be better as f-strings.
+  "PERF",  # Catch things that can slow down the application like unnecessary casts to list.
+  "RUF001",
+  "RUF002",
+  "RUF003",  # Ambiguous unicode characters
+  "RUF005",  # Encourages unpacking rather than concatenation
+  "RUF008",  # Do not use mutable default values for dataclass attributes
+  "B035",  # Don't use static keys in dict comprehensions.
+  "RUF013",  # Prohibit implicit Optionals (PEP 484)
+  "RUF100",  # #noqa directive that doesn't flag anything
+  "RUF200",  # If ruff fails to parse pyproject.toml...
 ]
 ignore = [
-    #"E203",  # Whitespace before ":"  -- Commented because ruff doesn't currently check E203
-    "E501",   # Line too long (reason: ruff will automatically fix this for us)
-    "D105",   # Missing docstring in magic method (reason: magic methods already have definitions)
-    "D107",   # Missing docstring in __init__ (reason: documented in class docstring)
-    "D203",   # 1 blank line required before class docstring (reason: pep257 default)
-    "D213",   # Multi-line docstring summary should start at the second line (reason: pep257 default)
-    "D215",   # Section underline is over-indented (reason: pep257 default)
-    "A003",   # Class attribute shadowing built-in (reason: Class attributes don't often get bare references)
-    "SIM117", # Use a single `with` statement with multiple contexts instead of nested `with` statements
-    # (reason: this creates long lines that get wrapped and reduces readability)
-    "PLW1641", # eq-without-hash (most of our classes should be unhashable)
+  # "E203",  # Whitespace before ":"  -- Commented because ruff doesn't currently check E203
+  "E501",  # Line too long (reason: ruff will automatically fix this for us)
+  "D105",  # Missing docstring in magic method (reason: magic methods already have definitions)
+  "D107",  # Missing docstring in __init__ (reason: documented in class docstring)
+  "D203",  # 1 blank line required before class docstring (reason: pep257 default)
+  "D213",  # Multi-line docstring summary should start at the second line (reason: pep257 default)
+  "D215",  # Section underline is over-indented (reason: pep257 default)
+  "A003",  # Class attribute shadowing built-in (reason: Class attributes don't often get bare references)
+  "SIM117",  # Use a single `with` statement with multiple contexts instead of nested `with` statements
+  # (reason: this creates long lines that get wrapped and reduces readability)
+  "PLW1641",  # eq-without-hash (most of our classes should be unhashable)
 
-    # Ignored due to conflicts with ruff's formatter:
-    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
-    "COM812", # Missing trailing comma - mostly the same, but marginal differences.
-    "ISC001", # Single-line implicit string concatenation.
+  # Ignored due to conflicts with ruff's formatter:
+  # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+  "COM812",  # Missing trailing comma - mostly the same, but marginal differences.
+  "ISC001",  # Single-line implicit string concatenation.
 
-    # Ignored due to common usage in current code
-    "TRY003", # Avoid specifying long messages outside the exception class
+  # Ignored due to common usage in current code
+  "TRY003",  # Avoid specifying long messages outside the exception class
 ]
 
 [tool.ruff.lint.flake8-annotations]
@@ -331,13 +264,13 @@ allow-star-arg-any = true
 strict-checking = true
 
 [tool.ruff.lint.pydocstyle]
-ignore-decorators = [ # Functions with these decorators don't have to have docstrings.
-    "typing.overload", # Default configuration
-    # The next four are all variations on override, so child classes don't have to repeat parent classes' docstrings.
-    "overrides.override",
-    "overrides.overrides",
-    "typing.override",
-    "typing_extensions.override",
+ignore-decorators = [  # Functions with these decorators don't have to have docstrings.
+  "typing.overload",  # Default configuration
+  # The next four are all variations on override, so child classes don't have to repeat parent classes' docstrings.
+  "overrides.override",
+  "overrides.overrides",
+  "typing.override",
+  "typing_extensions.override",
 ]
 
 [tool.ruff.lint.pylint]
@@ -348,21 +281,86 @@ max-args = 8
 classmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**.py" = [ # Some things we want for the main project are unnecessary in tests.
-    "D",       # Ignore docstring rules in tests
-    "ANN",     # Ignore type annotations in tests
-    "ARG",     # Allow unused arguments in tests (e.g. for fake functions/methods/classes)
-    "S101",    # Allow assertions in tests
-    "S103",    # Allow `os.chmod` setting a permissive mask `0o555` on file or directory
-    "S108",    # Allow Probable insecure usage of temporary file or directory
-    "PLR0913", # Allow many arguments for test functions (useful if we need many fixtures)
-    "PLR0917", # Allow many positional arguments for test functions (useful if we need many fixtures)
-    "PLR2004", # Allow magic values in tests
-    "SLF",     # Allow accessing private members from tests.
-    "FBT001",  # Boolean-typed positional arguments are common in tests (e.g. parametrize)
-    "FBT002",  # Boolean default values are common in test helper functions
+"tests/**.py" = [  # Some things we want for the main project are unnecessary in tests.
+  "D",  # Ignore docstring rules in tests
+  "ANN",  # Ignore type annotations in tests
+  "ARG",  # Allow unused arguments in tests (e.g. for fake functions/methods/classes)
+  "S101",  # Allow assertions in tests
+  "S103",  # Allow `os.chmod` setting a permissive mask `0o555` on file or directory
+  "S108",  # Allow Probable insecure usage of temporary file or directory
+  "PLR0913",  # Allow many arguments for test functions (useful if we need many fixtures)
+  "PLR0917",  # Allow many positional arguments for test functions (useful if we need many fixtures)
+  "PLR2004",  # Allow magic values in tests
+  "SLF",  # Allow accessing private members from tests.
+  "FBT001",  # Boolean-typed positional arguments are common in tests (e.g. parametrize)
+  "FBT002",  # Boolean default values are common in test helper functions
 ]
 "__init__.py" = [
-    "I001", # isort leaves init files alone by default, this makes ruff ignore them too.
-    "F401", # Allows unused imports in __init__ files.
+  "I001",  # isort leaves init files alone by default, this makes ruff ignore them too.
+  "F401",  # Allows unused imports in __init__ files.
+]
+
+[tool.setuptools.packages.find]
+include = ["*craft*"]
+namespaces = false
+
+[tool.setuptools_scm]
+write_to = "starcraft/_version.py"
+# the version comes from the latest annotated git tag formatted as 'X.Y.Z'
+# version scheme:
+#   - X.Y.Z.post<commits since tag>+g<hash>.d<%Y%m%d>
+# parts of scheme:
+#   - X.Y.Z - most recent git tag
+#   - post<commits since tag>+g<hash> - present when current commit is not tagged
+#   - .d<%Y%m%d> - present when working dir is dirty
+# version scheme when no tags exist:
+#   - 0.0.post<total commits>+g<hash>
+version_scheme = "post-release"
+# deviations from the default 'git describe' command:
+# - only match annotated tags
+# - only match tags formatted as 'X.Y.Z'
+git_describe_command = [
+  "git",
+  "describe",
+  "--dirty",
+  "--long",
+  "--match",
+  "[0-9]*.[0-9]*.[0-9]*",
+  "--exclude",
+  "*[^0-9.]*",
+]
+
+[tool.uv]
+constraint-dependencies = [
+  # Basic constraints to allow --resolution=lowest.
+  #
+  # Libraries should avoid CVEs in direct and transitive dependencies by setting a
+  # minimum version in this section.
+  # This allows standalone builds to avoid CVEs while not placing undue constraints on
+  # downstream users of the library.
+  #
+  # Applications should avoid CVEs in transitive dependencies by setting a minimum
+  # version in this section.
+  "cffi>=1.15",
+  "iniconfig>=1.1.0",
+  "httplib2>=0.20.0",
+  "libnacl>=2.0",
+  "lxml>=5.0",
+  "markdown>=3.0",
+  "markupsafe>=2.0",
+  "oauthlib>=3.0.0",
+  "protobuf>=5.0",
+  "pynacl>=1.5",
+  "pyparsing>=3.0.0",
+  "pyproject-hooks>=1.0.0",
+  "pytz>=2020",
+  "pyyaml>=5.0",
+  "regex>=2021.11.10",
+  "setuptools>=50",
+  "sphinx-basic-ng>=1.0.0b1",
+  "starlette>=1.0.1",
+  "tornado>=4.0",
+  "urllib3>=2.0",
+  "webencodings>=0.4.0",
+  "wheel>=0.38",
 ]


### PR DESCRIPTION
The TOML formatters to choose from were taplo (in some sort of maybe-maintained-maybe-not limbo), even-better-toml which seems to just be a wrapper on taplo anyways, and tombi.

Notably, tombi has the nice feature of being configurable via `[tool.tombi]` in `pyproject.toml` so we don't even need to add a fiftieth config file!

Closes #437.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/starbase/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
